### PR TITLE
fix: use email from DB to block duplicate voters

### DIFF
--- a/src/components/pages/ValidateVoterPage.jsx
+++ b/src/components/pages/ValidateVoterPage.jsx
@@ -56,8 +56,8 @@ class ValidateVoterPage extends Component {
         .database()
         .ref()
         .child("voters")
-        .orderByChild("ccid")
-        .equalTo(ccid)
+        .orderByChild("email")
+        .equalTo(email)
         .once("value", snapshot => {
           const hasVotedBefore = snapshot.numChildren();
           hasVotedBefore
@@ -88,9 +88,7 @@ class ValidateVoterPage extends Component {
   renderEligibleVoterForm = () => {
     const { email, adasTeamEvent, agreeToBeHonest } = this.state;
     const isInvalid =
-      !/@ualberta.ca\s*$/.test(email) ||
-      adasTeamEvent.length === 0 ||
-      !agreeToBeHonest;
+      email === "" || adasTeamEvent.length === 0 || !agreeToBeHonest;
 
     return (
       <Form size="big">

--- a/src/firebase/config/database.rules.json
+++ b/src/firebase/config/database.rules.json
@@ -3,7 +3,7 @@
     ".read": true,
     ".write": true,
     "voters": {
-      ".indexOn": "ccid"
+      ".indexOn": "email"
     }
   }
 }


### PR DESCRIPTION
We realized that some eligible voters can be a non-ualberta student. Therefore, we need amend validation to be with email, not ccid.

**Changes**
* Retrieve email from DB to block duplicate voters
* Amend firebase rules to indexOn email, not ccid

**UI**
* No visible changes in the UI