### PR TITLE
fix: widen load eligibility screen to avoid cut-off

### DIFF
--- a/src/components/ValidateVoter/LoadEligibility.jsx
+++ b/src/components/ValidateVoter/LoadEligibility.jsx
@@ -92,7 +92,7 @@ class LoadEligibility extends Component {
 
     return (
       <GridContainer verticalAlign="middle" centered columns={1}>
-        <Grid.Column width={6}>
+        <Grid.Column width={5}>
           <Image size="huge" src={AdaBotHeadImage} alt="Ada Bot Head" />
           <Progress color="blue" percent={30}></Progress>
           <Message size="massive" color={messageBgColor} icon>

--- a/src/components/ValidateVoter/LoadEligibility.jsx
+++ b/src/components/ValidateVoter/LoadEligibility.jsx
@@ -92,7 +92,7 @@ class LoadEligibility extends Component {
 
     return (
       <GridContainer verticalAlign="middle" centered columns={1}>
-        <Grid.Column width={4}>
+        <Grid.Column width={6}>
           <Image size="huge" src={AdaBotHeadImage} alt="Ada Bot Head" />
           <Progress color="blue" percent={30}></Progress>
           <Message size="massive" color={messageBgColor} icon>


### PR DESCRIPTION
**Changes**
- widened width of the `LoadingEligibility` screen

**UI**
![Screen Shot 2020-03-26 at 11 54 03 PM](https://user-images.githubusercontent.com/23146829/77726245-1a5c9a80-6fbd-11ea-8501-808c23bcfcba.png)

