### PR TITLE
fix: add stackable property to cards for viewing in mobile

### DIFF
--- a/src/components/pages/Results.jsx
+++ b/src/components/pages/Results.jsx
@@ -46,7 +46,7 @@ class Results extends Component {
         </Subheader>
         <Divider />
 
-        <Card.Group doubling itemsPerRow={5} stackable>
+        <Card.Group itemsPerRow={5} stackable>
           {_.map(resultCards, card => (
             <Card key={card.header}>
               {loading ? (

--- a/src/components/votepart/ListCandidates.jsx
+++ b/src/components/votepart/ListCandidates.jsx
@@ -48,7 +48,7 @@ class ListCandidates extends Component {
     return (
       <Form>
         <Form.Group grouped widths="equal">
-          <Card.Group itemsPerRow={5}>
+          <Card.Group stackable itemsPerRow={5}>
             {this.renderCandidates(position)}
           </Card.Group>
         </Form.Group>


### PR DESCRIPTION
**Changes**
- added stackable prop to `<Card.Group ... />` components

**UI**
> **Example**
> <img width="278" alt="Screen Shot 2020-03-28 at 12 44 40 AM" src="https://user-images.githubusercontent.com/23146829/77817020-54956d00-708d-11ea-86c9-f64a2035530c.png">
