### PR TITLE
fix: set results page back to loading screen

### DIFF
--- a/src/components/pages/Results.jsx
+++ b/src/components/pages/Results.jsx
@@ -1,6 +1,6 @@
+import React, { Component, Fragment } from "react";
 import style from "styled-components";
 import { getPositions, getCandidateList } from "../helper";
-import React, { Component, Fragment } from "react";
 import { Card, Divider, Image, Placeholder } from "semantic-ui-react";
 import PlaceholderImg from "../../assets/Daniel.jpg";
 import firebase from "firebase/app";
@@ -31,7 +31,7 @@ class Results extends Component {
   constructor() {
     super();
     this.state = {
-      loading: false,
+      loading: true,
       candidateList: {},
       winners: {}
     };


### PR DESCRIPTION
**Changes**
- set `loading` to true to render loading screen again

**UI**
> <img width="1792" alt="Screen Shot 2020-04-01 at 3 01 28 AM" src="https://user-images.githubusercontent.com/23146829/78119087-1ec1f280-73c5-11ea-945e-3eb57d80dfd7.png">
