### PR TITLE
feat: popup message trigger and voter page description

### DIFF
--- a/src/components/VotePart/Position.jsx
+++ b/src/components/VotePart/Position.jsx
@@ -7,9 +7,18 @@ const PopupMessage = style(Popup)`
   font-size: 16px !important;
   max-width: 62.5% !important; 
 `;
+
+const PositionName = style.h1`
+  width: fit-content;
+`;
+
 const Position = ({ name }) => {
   return (
-    <PopupMessage wide="very" trigger={<h1>{name}</h1>} position="top left">
+    <PopupMessage
+      wide="very"
+      trigger={<PositionName>{name}</PositionName>}
+      position="top left"
+    >
       {positionDesc[0][name]}
     </PopupMessage>
   );

--- a/src/components/VotePart/Vote.jsx
+++ b/src/components/VotePart/Vote.jsx
@@ -186,6 +186,9 @@ class Vote extends Component {
         <Grid.Column width={10}>
           <VoteHeader>Vote</VoteHeader>
           <Subheader>
+            Hover over the position name to get its description.
+          </Subheader>
+          <Subheader>
             If you leave this page before submitting, your vote will not be
             counted.
           </Subheader>


### PR DESCRIPTION
**Changes**
- added description to hover position name to get details
- fixed popup trigger to the width of the position name and not its container

**UI**
> ![Screen Shot 2020-04-02 at 10 17 27 PM](https://user-images.githubusercontent.com/23146829/78323663-c2c7ad00-752f-11ea-9adb-8da4b1253ced.png)

