### PR TITLE
fix: deleted neutral party from mailing list

### DIFF
--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -182,7 +182,7 @@ const candidates = {
     name: "Celina Sheng",
     speech: `Hi, my name is Celina Sheng, and I am running for VP Finance, VP Campus Outreach, or President. In the past year, I had the opportunity to be VP Communications. I wrote up Ada's Team's newsletters and posted events to our social media accounts. Through our Tech Star panel and advertising the diverse events forwarded to us, I took steps towards fostering an inclusive environment. I am running for a new executive position because I want to continue my community involvement while trying out new responsibilities. Additionally, I love that Ada's Team feels like a family, and I want our future execs to feel the same way. I would recommend anyone who wants to be more involved in the CS community to help out with any of Ada's Teams initiatives.`,
     photoSrc: "/candidatePhotos/csheng2.jpg",
-    preferences: ["VP Finance", "VP Campus Outreach"]
+    preferences: ["VP Finance", "VP Campus Outreach", "VP Admin"]
   },
   "Nadeen Mohamed": {
     email: "nadeen@ualberta.ca",

--- a/src/firebase/mailingList/mailingList.json
+++ b/src/firebase/mailingList/mailingList.json
@@ -1800,11 +1800,6 @@
     "Email Address": "gtkahsay@ualberta.ca"
   },
   {
-    "First Name": "Chelsea",
-    "Last Name": "Hong",
-    "Email Address": "chelsea4@ualberta.ca"
-  },
-  {
     "First Name": "",
     "Last Name": "",
     "Email Address": "wendy.zwd@gmail.com"

--- a/src/firebase/mailingList/mailingList.json
+++ b/src/firebase/mailingList/mailingList.json
@@ -1,5822 +1,5842 @@
 [
   {
+    "Email Address": "shah4@ualberta.ca",
     "First Name": "Shaishav",
-    "Last Name": "Shah",
-    "Email Address": "shah4@ualberta.ca"
+    "Last Name": "Shah"
   },
   {
+    "Email Address": "hgou@ualberta.ca",
     "First Name": "Haochen",
-    "Last Name": "Gou",
-    "Email Address": "hgou@ualberta.ca"
+    "Last Name": "Gou"
   },
   {
+    "Email Address": "akshatpandeymyself@gmail.com",
     "First Name": "Akshat",
-    "Last Name": "Pandey",
-    "Email Address": "akshatpandeymyself@gmail.com"
+    "Last Name": "Pandey"
   },
   {
+    "Email Address": "nawreen@ualberta.ca",
     "First Name": "Nawreen",
-    "Last Name": "Hena",
-    "Email Address": "nawreen@ualberta.ca"
+    "Last Name": "Hena"
   },
   {
+    "Email Address": "xn@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xn@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kaiyi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kaiyi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "snchan1@ualberta.ca",
     "First Name": "Sam",
-    "Last Name": "Chan",
-    "Email Address": "snchan1@ualberta.ca"
+    "Last Name": "Chan"
   },
   {
+    "Email Address": "josephm340@gmail.com",
     "First Name": "Joseph",
-    "Last Name": "Menezes",
-    "Email Address": "josephm340@gmail.com"
+    "Last Name": "Menezes"
   },
   {
+    "Email Address": "easantos@ualberta.ca",
     "First Name": "Eddie",
-    "Last Name": "Santos",
-    "Email Address": "easantos@ualberta.ca"
+    "Last Name": "Santos"
   },
   {
+    "Email Address": "paritosh@ualberta.ca",
     "First Name": "Paritosh",
-    "Last Name": "Goyal",
-    "Email Address": "paritosh@ualberta.ca"
+    "Last Name": "Goyal"
   },
   {
+    "Email Address": "nfhanna@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nfhanna@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tkhalid@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tkhalid@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hareeme@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hareeme@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tarabhatia@berkeley.edu",
     "First Name": "Tara",
-    "Last Name": "Bhatia",
-    "Email Address": "tarabhatia@berkeley.edu"
+    "Last Name": "Bhatia"
   },
   {
+    "Email Address": "cchen1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cchen1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ktran5@ualberta.ca",
     "First Name": "Kimberly",
-    "Last Name": "Tran",
-    "Email Address": "ktran5@ualberta.ca"
+    "Last Name": "Tran"
   },
   {
+    "Email Address": "jlovas@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jlovas@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "isabella@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "isabella@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mehakarif019@gmail.com",
     "First Name": "Mehak",
-    "Last Name": "",
-    "Email Address": "mehakarif019@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "amali@ualberta.ca",
     "First Name": "Ahmad",
-    "Last Name": "Amali",
-    "Email Address": "amali@ualberta.ca"
+    "Last Name": "Amali"
   },
   {
+    "Email Address": "jhuard@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jhuard@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yamini@iastate.edu",
     "First Name": "Yamini",
-    "Last Name": "Mathur",
-    "Email Address": "yamini@iastate.edu"
+    "Last Name": "Mathur"
   },
   {
+    "Email Address": "advik@ualberta.ca",
     "First Name": "Advik",
-    "Last Name": "Mehta",
-    "Email Address": "advik@ualberta.ca"
+    "Last Name": "Mehta"
   },
   {
+    "Email Address": "patenio@ualberta.ca",
     "First Name": "Katherine",
-    "Last Name": "Patenio",
-    "Email Address": "patenio@ualberta.ca"
+    "Last Name": "Patenio"
   },
   {
+    "Email Address": "ksee94@seas.upenn.edu",
     "First Name": "Kenneth",
-    "Last Name": "See",
-    "Email Address": "ksee94@seas.upenn.edu"
+    "Last Name": "See"
   },
   {
+    "Email Address": "sharyar@ualberta.ca",
     "First Name": "Sharyar",
-    "Last Name": "Memon",
-    "Email Address": "sharyar@ualberta.ca"
+    "Last Name": "Memon"
   },
   {
+    "Email Address": "bchughta@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bchughta@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mobashhi@ualberta.ca",
     "First Name": "Mobashhir",
-    "Last Name": "Khan",
-    "Email Address": "mobashhi@ualberta.ca"
+    "Last Name": "Khan"
   },
   {
+    "Email Address": "1000177818@ualberta.ca",
     "First Name": "Sam",
-    "Last Name": "Chan",
-    "Email Address": "1000177818@ualberta.ca"
+    "Last Name": "Chan"
   },
   {
+    "Email Address": "Fbonilla@ualberta.ca",
     "First Name": "Fred",
-    "Last Name": "Bonilla",
-    "Email Address": "Fbonilla@ualberta.ca"
+    "Last Name": "Bonilla"
   },
   {
+    "Email Address": "brookerapaich@gmail.com",
     "First Name": "Brooke",
-    "Last Name": "",
-    "Email Address": "brookerapaich@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "anushajayadev@gmail.com",
     "First Name": "Anusha",
-    "Last Name": "Jayadev",
-    "Email Address": "anushajayadev@gmail.com"
+    "Last Name": "Jayadev"
   },
   {
+    "Email Address": "clo1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "clo1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tanvi.sharma@sjsu.edu",
     "First Name": "Tanvi",
-    "Last Name": "Sharma",
-    "Email Address": "tanvi.sharma@sjsu.edu"
+    "Last Name": "Sharma"
   },
   {
+    "Email Address": "mmao@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mmao@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nnissen@ualberta.ca",
     "First Name": "Nick",
-    "Last Name": "Nissen",
-    "Email Address": "nnissen@ualberta.ca"
+    "Last Name": "Nissen"
   },
   {
+    "Email Address": "wok@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "wok@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sara.kourkmas@hotmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sara.kourkmas@hotmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "dokken1@ualberta.ca",
     "First Name": "Hannah",
-    "Last Name": "Dokken",
-    "Email Address": "dokken1@ualberta.ca"
+    "Last Name": "Dokken"
   },
   {
+    "Email Address": "aporthuk@ualberta.ca",
     "First Name": "Annie",
-    "Last Name": "Porthukaran",
-    "Email Address": "aporthuk@ualberta.ca"
+    "Last Name": "Porthukaran"
   },
   {
+    "Email Address": "lakshmic@buffalo.edu",
     "First Name": "Lakshmi Chaitanya",
-    "Last Name": "Chapala",
-    "Email Address": "lakshmic@buffalo.edu"
+    "Last Name": "Chapala"
   },
   {
+    "Email Address": "leahsummers@improbable.io",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "leahsummers@improbable.io"
+    "Last Name": ""
   },
   {
+    "Email Address": "hillaryhuynh22@gmail.com",
     "First Name": "Hillary",
-    "Last Name": "",
-    "Email Address": "hillaryhuynh22@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "jiayun@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jiayun@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "asun3@ualberta.ca",
     "First Name": "Amelia",
-    "Last Name": "Sun",
-    "Email Address": "asun3@ualberta.ca"
+    "Last Name": "Sun"
   },
   {
+    "Email Address": "elake@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "elake@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nubianlewis@hotmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nubianlewis@hotmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "vasavi.l.garimella.22@dartmouth.edu",
     "First Name": "Mimi",
-    "Last Name": "Garimella",
-    "Email Address": "vasavi.l.garimella.22@dartmouth.edu"
+    "Last Name": "Garimella"
   },
   {
+    "Email Address": "sukanta@ualberta.ca",
     "First Name": "Sukanta",
-    "Last Name": "Saha",
-    "Email Address": "sukanta@ualberta.ca"
+    "Last Name": "Saha"
   },
   {
+    "Email Address": "christine_waweru@brown.edu",
     "First Name": "Christine",
-    "Last Name": "Waweru",
-    "Email Address": "christine_waweru@brown.edu"
+    "Last Name": "Waweru"
   },
   {
+    "Email Address": "cdhamija@ualberta.ca",
     "First Name": "Charvi",
-    "Last Name": "Dhamija",
-    "Email Address": "cdhamija@ualberta.ca"
+    "Last Name": "Dhamija"
   },
   {
+    "Email Address": "amwong1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "amwong1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "relhajj@ualberta.ca",
     "First Name": "Rehab",
-    "Last Name": "El-Hajj",
-    "Email Address": "relhajj@ualberta.ca"
+    "Last Name": "El-Hajj"
   },
   {
+    "Email Address": "arjun.mehta1001@gmail.com",
     "First Name": "Arjun",
-    "Last Name": "Mehta",
-    "Email Address": "arjun.mehta1001@gmail.com"
+    "Last Name": "Mehta"
   },
   {
+    "Email Address": "carolyn.re.yang@gmail.com",
     "First Name": "Carolyn",
-    "Last Name": "Yang",
-    "Email Address": "carolyn.re.yang@gmail.com"
+    "Last Name": "Yang"
   },
   {
+    "Email Address": "subohiagarwal2001@gmail.com",
     "First Name": "Subohi",
-    "Last Name": "Agarwal",
-    "Email Address": "subohiagarwal2001@gmail.com"
+    "Last Name": "Agarwal"
   },
   {
+    "Email Address": "romansky@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "romansky@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "timsafiqulamin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "timsafiqulamin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sivadasa@ualberta.ca",
     "First Name": "Gokul",
-    "Last Name": "Sivadasan",
-    "Email Address": "sivadasa@ualberta.ca"
+    "Last Name": "Sivadasan"
   },
   {
+    "Email Address": "almonte@ualberta.ca",
     "First Name": "Amrees",
-    "Last Name": "Almonte",
-    "Email Address": "almonte@ualberta.ca"
+    "Last Name": "Almonte"
   },
   {
+    "Email Address": "anacod@zoho.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "anacod@zoho.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "iqureshi@ualberta.ca",
     "First Name": "Iman",
-    "Last Name": "Qureshi",
-    "Email Address": "iqureshi@ualberta.ca"
+    "Last Name": "Qureshi"
   },
   {
+    "Email Address": "ai4s@ualberta.ca",
     "First Name": "Amy",
-    "Last Name": "Vachon-Chabot",
-    "Email Address": "ai4s@ualberta.ca"
+    "Last Name": "Vachon-Chabot"
   },
   {
+    "Email Address": "nimita.atal@gmail.com",
     "First Name": "Nimita Shyamsunder",
-    "Last Name": "Atal",
-    "Email Address": "nimita.atal@gmail.com"
+    "Last Name": "Atal"
   },
   {
+    "Email Address": "2707893@school.ecsd.net",
     "First Name": "Jasmin",
-    "Last Name": "Jeong",
-    "Email Address": "2707893@school.ecsd.net"
+    "Last Name": "Jeong"
   },
   {
+    "Email Address": "corinna.kelly@outlook.com",
     "First Name": "Corinna",
-    "Last Name": "Kelly",
-    "Email Address": "corinna.kelly@outlook.com"
+    "Last Name": "Kelly"
   },
   {
+    "Email Address": "qgao1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qgao1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "vprakash@ualberta.ca",
     "First Name": "Varshini",
-    "Last Name": "Prakash",
-    "Email Address": "vprakash@ualberta.ca"
+    "Last Name": "Prakash"
   },
   {
+    "Email Address": "alqueza@ualberta.ca",
     "First Name": "Jerwyn",
-    "Last Name": "Alqueza",
-    "Email Address": "alqueza@ualberta.ca"
+    "Last Name": "Alqueza"
   },
   {
+    "Email Address": "kylezwarich@ualberta.ca",
     "First Name": "Kyle",
-    "Last Name": "Zwarich",
-    "Email Address": "kylezwarich@ualberta.ca"
+    "Last Name": "Zwarich"
   },
   {
+    "Email Address": "yile@ualberta.ca",
     "First Name": "Yile",
-    "Last Name": "Ma",
-    "Email Address": "yile@ualberta.ca"
+    "Last Name": "Ma"
   },
   {
+    "Email Address": "baohui@ualberta.ca",
     "First Name": "Charffy",
-    "Last Name": "Wang",
-    "Email Address": "baohui@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "opgenort@ualberta.ca",
     "First Name": "Jack",
-    "Last Name": "Opgenorth",
-    "Email Address": "opgenort@ualberta.ca"
+    "Last Name": "Opgenorth"
   },
   {
+    "Email Address": "karnavee.kamdar@sjsu.edu",
     "First Name": "Karnavee",
-    "Last Name": "Kamdar",
-    "Email Address": "karnavee.kamdar@sjsu.edu"
+    "Last Name": "Kamdar"
   },
   {
+    "Email Address": "aissa1@ualberta.ca",
     "First Name": "Abdulaziz",
-    "Last Name": "Issa",
-    "Email Address": "aissa1@ualberta.ca"
+    "Last Name": "Issa"
   },
   {
+    "Email Address": "zhihai1@ualberta.ca",
     "First Name": "Wilson",
-    "Last Name": "Yao",
-    "Email Address": "zhihai1@ualberta.ca"
+    "Last Name": "Yao"
   },
   {
+    "Email Address": "kenji1@ualberta.ca",
     "First Name": "Kenji",
-    "Last Name": "Au",
-    "Email Address": "kenji1@ualberta.ca"
+    "Last Name": "Au"
   },
   {
+    "Email Address": "vanessa.hernandez2478@gmail.com",
     "First Name": "Vanesa",
-    "Last Name": "Hernandez",
-    "Email Address": "vanessa.hernandez2478@gmail.com"
+    "Last Name": "Hernandez"
   },
   {
+    "Email Address": "tianzhi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tianzhi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "zetping@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "zetping@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sarikond@ualberta.ca",
     "First Name": "Jashwanth Reddy",
-    "Last Name": "Sarikonda",
-    "Email Address": "sarikond@ualberta.ca"
+    "Last Name": "Sarikonda"
   },
   {
+    "Email Address": "yamini.nekkanti1@gmail.com",
     "First Name": "Yamini",
-    "Last Name": "Nekkanti",
-    "Email Address": "yamini.nekkanti1@gmail.com"
+    "Last Name": "Nekkanti"
   },
   {
+    "Email Address": "bhattacharya.s@northeastern.edu",
     "First Name": "Sounak",
-    "Last Name": "Bhattacharya",
-    "Email Address": "bhattacharya.s@northeastern.edu"
+    "Last Name": "Bhattacharya"
   },
   {
+    "Email Address": "kashish2@ualberta.ca",
     "First Name": "Kashish",
-    "Last Name": "Aggarwal",
-    "Email Address": "kashish2@ualberta.ca"
+    "Last Name": "Aggarwal"
   },
   {
+    "Email Address": "sgarg2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sgarg2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "amelie.jkhan@gmail.com",
     "First Name": "Amelie",
-    "Last Name": "Khan",
-    "Email Address": "amelie.jkhan@gmail.com"
+    "Last Name": "Khan"
   },
   {
+    "Email Address": "joe2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "joe2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sriramka@ualberta.ca",
     "First Name": "Sriram Karthik",
-    "Last Name": "Akella",
-    "Email Address": "sriramka@ualberta.ca"
+    "Last Name": "Akella"
   },
   {
+    "Email Address": "p8f2b@ugrad.cs.ubc.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "p8f2b@ugrad.cs.ubc.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "cspang@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cspang@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "Rnayar@ualberta.ca",
     "First Name": "Radhika",
-    "Last Name": "Nayar",
-    "Email Address": "Rnayar@ualberta.ca"
+    "Last Name": "Nayar"
   },
   {
+    "Email Address": "llanos@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "llanos@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "bintemoi@ualberta.ca",
     "First Name": "Maisha",
-    "Last Name": "Binte Moin",
-    "Email Address": "bintemoi@ualberta.ca"
+    "Last Name": "Binte Moin"
   },
   {
+    "Email Address": "tanishkabansal@outlook.com",
     "First Name": "Tanishka",
-    "Last Name": "Bansal",
-    "Email Address": "tanishkabansal@outlook.com"
+    "Last Name": "Bansal"
   },
   {
+    "Email Address": "aaryn.flynn@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aaryn.flynn@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "msumner@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "msumner@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kearney@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kearney@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hkang@ualberta.ca",
     "First Name": "Brian",
-    "Last Name": "Kang",
-    "Email Address": "hkang@ualberta.ca"
+    "Last Name": "Kang"
   },
   {
+    "Email Address": "langmi@ualberta.ca",
     "First Name": "Brandon",
-    "Last Name": "Langmi",
-    "Email Address": "langmi@ualberta.ca"
+    "Last Name": "Langmi"
   },
   {
+    "Email Address": "nyitrai@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nyitrai@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "xq4@ualberta.ca",
     "First Name": "XUEYAN",
-    "Last Name": "QIN",
-    "Email Address": "xq4@ualberta.ca"
+    "Last Name": "QIN"
   },
   {
+    "Email Address": "praneethajampani@gmail.com",
     "First Name": "Praneetha",
-    "Last Name": "Jampani",
-    "Email Address": "praneethajampani@gmail.com"
+    "Last Name": "Jampani"
   },
   {
+    "Email Address": "mdacosta@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mdacosta@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "chik@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "chik@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "neerajsuresh02@gmail.com",
     "First Name": "Neeraj",
-    "Last Name": "Suresh",
-    "Email Address": "neerajsuresh02@gmail.com"
+    "Last Name": "Suresh"
   },
   {
+    "Email Address": "mo@mohammad.dev",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mo@mohammad.dev"
+    "Last Name": ""
   },
   {
+    "Email Address": "blossomyyh@gmail.com",
     "First Name": "Blossom",
-    "Last Name": "Yin",
-    "Email Address": "blossomyyh@gmail.com"
+    "Last Name": "Yin"
   },
   {
+    "Email Address": "gurveersohal433@gmail.com",
     "First Name": "Gurveer",
-    "Last Name": "Sohal",
-    "Email Address": "gurveersohal433@gmail.com"
+    "Last Name": "Sohal"
   },
   {
+    "Email Address": "fugakureha@hotmail.co.jp",
     "First Name": "Mimi",
-    "Last Name": "Tada",
-    "Email Address": "fugakureha@hotmail.co.jp"
+    "Last Name": "Tada"
   },
   {
+    "Email Address": "cxz424@case.edu",
     "First Name": "Caroline",
-    "Last Name": "Zhu",
-    "Email Address": "cxz424@case.edu"
+    "Last Name": "Zhu"
   },
   {
+    "Email Address": "zeineb@minerva.kgi.edu",
     "First Name": "Zeineb",
-    "Last Name": "Ouerghi",
-    "Email Address": "zeineb@minerva.kgi.edu"
+    "Last Name": "Ouerghi"
   },
   {
+    "Email Address": "aksshat@ualberta.ca",
     "First Name": "Aksshat",
-    "Last Name": "Khanna",
-    "Email Address": "aksshat@ualberta.ca"
+    "Last Name": "Khanna"
   },
   {
+    "Email Address": "revan@ualberta.ca",
     "First Name": "Revan",
-    "Last Name": "MacQueen",
-    "Email Address": "revan@ualberta.ca"
+    "Last Name": "MacQueen"
   },
   {
+    "Email Address": "shrest5@warhawks.ulm.edu",
     "First Name": "Shrill",
-    "Last Name": "Shrestha",
-    "Email Address": "shrest5@warhawks.ulm.edu"
+    "Last Name": "Shrestha"
   },
   {
+    "Email Address": "islam9@ualberta.ca",
     "First Name": "Md Manirul",
-    "Last Name": "Islam",
-    "Email Address": "islam9@ualberta.ca"
+    "Last Name": "Islam"
   },
   {
+    "Email Address": "sswastik2001@gmail.com",
     "First Name": "Swastik",
-    "Last Name": "Sharma",
-    "Email Address": "sswastik2001@gmail.com"
+    "Last Name": "Sharma"
   },
   {
+    "Email Address": "palmers@ualberta.ca",
     "First Name": "Sally",
-    "Last Name": "Palmers",
-    "Email Address": "palmers@ualberta.ca"
+    "Last Name": "Palmers"
   },
   {
+    "Email Address": "dhruvraj@ualberta.ca",
     "First Name": "Dhruvraj",
-    "Last Name": "Singh",
-    "Email Address": "dhruvraj@ualberta.ca"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "zerihoun@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "zerihoun@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sxshabbir@ualr.edu",
     "First Name": "Samra",
-    "Last Name": "Shabbir",
-    "Email Address": "sxshabbir@ualr.edu"
+    "Last Name": "Shabbir"
   },
   {
+    "Email Address": "nhnguyen@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nhnguyen@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gara@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gara@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "poulomi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "poulomi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "paulanje@ualberta.ca",
     "First Name": "Paul Anjelyno",
-    "Last Name": "Bakshi",
-    "Email Address": "paulanje@ualberta.ca"
+    "Last Name": "Bakshi"
   },
   {
+    "Email Address": "ebarron@ualberta.ca",
     "First Name": "Lizzy",
-    "Last Name": "Barron",
-    "Email Address": "ebarron@ualberta.ca"
+    "Last Name": "Barron"
   },
   {
+    "Email Address": "pajamagoat@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "pajamagoat@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "zichong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "zichong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jlatta@ualberta.ca",
     "First Name": "Jadon",
-    "Last Name": "Latta",
-    "Email Address": "jlatta@ualberta.ca"
+    "Last Name": "Latta"
   },
   {
+    "Email Address": "natashalraffa@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "natashalraffa@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "rupali1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rupali1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aayushmal@outlook.com",
     "First Name": "Aayush",
-    "Last Name": "Malhotra",
-    "Email Address": "aayushmal@outlook.com"
+    "Last Name": "Malhotra"
   },
   {
+    "Email Address": "v48patel@gmail.com",
     "First Name": "Vivek",
-    "Last Name": "Patel",
-    "Email Address": "v48patel@gmail.com"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "tokon@ualberta.ca",
     "First Name": "Mahajabin",
-    "Last Name": "Tokon",
-    "Email Address": "tokon@ualberta.ca"
+    "Last Name": "Tokon"
   },
   {
+    "Email Address": "misay@ualberta.ca",
     "First Name": "Kaye Ena Crayzhel",
-    "Last Name": "Misay",
-    "Email Address": "misay@ualberta.ca"
+    "Last Name": "Misay"
   },
   {
+    "Email Address": "yiji1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yiji1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "relmaada@ualberta.ca",
     "First Name": "Rawan",
-    "Last Name": "el maadawy",
-    "Email Address": "relmaada@ualberta.ca"
+    "Last Name": "el maadawy"
   },
   {
+    "Email Address": "qu8@ualberta.ca",
     "First Name": "YiJing",
-    "Last Name": "Qu",
-    "Email Address": "qu8@ualberta.ca"
+    "Last Name": "Qu"
   },
   {
+    "Email Address": "daniel.druce14@gmail.com",
     "First Name": "Daniel",
-    "Last Name": "Druce",
-    "Email Address": "daniel.druce14@gmail.com"
+    "Last Name": "Druce"
   },
   {
+    "Email Address": "bui1@ualberta.ca",
     "First Name": "Monica",
-    "Last Name": "Bui",
-    "Email Address": "bui1@ualberta.ca"
+    "Last Name": "Bui"
   },
   {
+    "Email Address": "sruduke@ualberta.ca",
     "First Name": "Sophia",
-    "Last Name": "Ruduke",
-    "Email Address": "sruduke@ualberta.ca"
+    "Last Name": "Ruduke"
   },
   {
+    "Email Address": "mmcote@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mmcote@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mlyu@ualberta.ca",
     "First Name": "Meilin",
-    "Last Name": "Lyu",
-    "Email Address": "mlyu@ualberta.ca"
+    "Last Name": "Lyu"
   },
   {
+    "Email Address": "rkdhatt@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rkdhatt@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "abhilask@andrew.cmu.edu",
     "First Name": "Abhilash",
-    "Last Name": "Kashyap",
-    "Email Address": "abhilask@andrew.cmu.edu"
+    "Last Name": "Kashyap"
   },
   {
+    "Email Address": "s55agarw@uwaterloo.ca",
     "First Name": "Saarang",
-    "Last Name": "Agarwal",
-    "Email Address": "s55agarw@uwaterloo.ca"
+    "Last Name": "Agarwal"
   },
   {
+    "Email Address": "thunt@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "thunt@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "prathamj@ualberta.ca",
     "First Name": "Pratham",
-    "Last Name": "Lakhani",
-    "Email Address": "prathamj@ualberta.ca"
+    "Last Name": "Lakhani"
   },
   {
+    "Email Address": "semirah.dolan@gmail.com",
     "First Name": "Semirah",
-    "Last Name": "Dolan",
-    "Email Address": "semirah.dolan@gmail.com"
+    "Last Name": "Dolan"
   },
   {
+    "Email Address": "kumar2@ualberta.ca",
     "First Name": "Mohit",
-    "Last Name": "Kumar",
-    "Email Address": "kumar2@ualberta.ca"
+    "Last Name": "Kumar"
   },
   {
+    "Email Address": "hessdorf@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hessdorf@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ssaini@ualberta.ca",
     "First Name": "Sankalp",
-    "Last Name": "Saini",
-    "Email Address": "ssaini@ualberta.ca"
+    "Last Name": "Saini"
   },
   {
+    "Email Address": "aaali@ualberta.ca",
     "First Name": "Asma",
-    "Last Name": "Omar",
-    "Email Address": "aaali@ualberta.ca"
+    "Last Name": "Omar"
   },
   {
+    "Email Address": "mehaksood10@gmail.com",
     "First Name": "Mehak",
-    "Last Name": "Sood",
-    "Email Address": "mehaksood10@gmail.com"
+    "Last Name": "Sood"
   },
   {
+    "Email Address": "mingli1@ualberta.ca",
     "First Name": "Andy",
-    "Last Name": "Han",
-    "Email Address": "mingli1@ualberta.ca"
+    "Last Name": "Han"
   },
   {
+    "Email Address": "dhawal@ualberta.ca",
     "First Name": "Dhawal",
-    "Last Name": "Gupta",
-    "Email Address": "dhawal@ualberta.ca"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "headrick@ualberta.ca",
     "First Name": "Devin",
-    "Last Name": "Headrick",
-    "Email Address": "headrick@ualberta.ca"
+    "Last Name": "Headrick"
   },
   {
+    "Email Address": "hoangtru@ualberta.ca",
     "First Name": "Trung",
-    "Last Name": "Nguyen",
-    "Email Address": "hoangtru@ualberta.ca"
+    "Last Name": "Nguyen"
   },
   {
+    "Email Address": "anujawani09@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "anujawani09@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "jensenfo@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jensenfo@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sshahid@adobe.com",
     "First Name": "Simra",
-    "Last Name": "Shahid",
-    "Email Address": "sshahid@adobe.com"
+    "Last Name": "Shahid"
   },
   {
+    "Email Address": "roshan.shariff@ualberta.ca",
     "First Name": "Roshan",
-    "Last Name": "Shariff",
-    "Email Address": "roshan.shariff@ualberta.ca"
+    "Last Name": "Shariff"
   },
   {
+    "Email Address": "deocampo@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "deocampo@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "divya.dayala@outlook.com",
     "First Name": "Divya",
-    "Last Name": "Dayala",
-    "Email Address": "divya.dayala@outlook.com"
+    "Last Name": "Dayala"
   },
   {
+    "Email Address": "hafez@ualberta.ca",
     "First Name": "Alireza",
-    "Last Name": "Hafez",
-    "Email Address": "hafez@ualberta.ca"
+    "Last Name": "Hafez"
   },
   {
+    "Email Address": "ddv246@nyu.edu",
     "First Name": "Daffney",
-    "Last Name": "Viswanath",
-    "Email Address": "ddv246@nyu.edu"
+    "Last Name": "Viswanath"
   },
   {
+    "Email Address": "tc8@ualberta.ca",
     "First Name": "Tianyi",
-    "Last Name": "Chen",
-    "Email Address": "tc8@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "jiavon@ualberta.ca",
     "First Name": "Jia",
-    "Last Name": "Then",
-    "Email Address": "jiavon@ualberta.ca"
+    "Last Name": "Then"
   },
   {
+    "Email Address": "dhirajnimbalkar@gmail.com",
     "First Name": "Dhiraj",
-    "Last Name": "Nimbalkar",
-    "Email Address": "dhirajnimbalkar@gmail.com"
+    "Last Name": "Nimbalkar"
   },
   {
+    "Email Address": "yimeng2@ualberta.ca",
     "First Name": "Yi Meng",
-    "Last Name": "Wang",
-    "Email Address": "yimeng2@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "idehaan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "idehaan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "pweckend@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "pweckend@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "waggoner@ualberta.ca",
     "First Name": "Karen",
-    "Last Name": "Waggoner",
-    "Email Address": "waggoner@ualberta.ca"
+    "Last Name": "Waggoner"
   },
   {
+    "Email Address": "haribs@live.com",
     "First Name": "Hari",
-    "Last Name": "Sridharala",
-    "Email Address": "haribs@live.com"
+    "Last Name": "Sridharala"
   },
   {
+    "Email Address": "richeek@ualberta.ca",
     "First Name": "Richeek",
-    "Last Name": "Mathur",
-    "Email Address": "richeek@ualberta.ca"
+    "Last Name": "Mathur"
   },
   {
+    "Email Address": "mshaheed@ualberta.ca",
     "First Name": "Maryam",
-    "Last Name": "Shaheed",
-    "Email Address": "mshaheed@ualberta.ca"
+    "Last Name": "Shaheed"
   },
   {
+    "Email Address": "ejmalone@ualberta.ca",
     "First Name": "Evan",
-    "Last Name": "Maloney",
-    "Email Address": "ejmalone@ualberta.ca"
+    "Last Name": "Maloney"
   },
   {
+    "Email Address": "genevieve.boniface92@gmail.com",
     "First Name": "Genevieve",
-    "Last Name": "Boniface",
-    "Email Address": "genevieve.boniface92@gmail.com"
+    "Last Name": "Boniface"
   },
   {
+    "Email Address": "thesunshinesitter@hotmail.com",
     "First Name": "Keeya",
-    "Last Name": "Beausoleil",
-    "Email Address": "thesunshinesitter@hotmail.com"
+    "Last Name": "Beausoleil"
   },
   {
+    "Email Address": "anjelica@ualberta.ca",
     "First Name": "Anjelica",
-    "Last Name": "Marianicz",
-    "Email Address": "anjelica@ualberta.ca"
+    "Last Name": "Marianicz"
   },
   {
+    "Email Address": "bdo1@ualberta.ca",
     "First Name": "Brian",
-    "Last Name": "D",
-    "Email Address": "bdo1@ualberta.ca"
+    "Last Name": "D"
   },
   {
+    "Email Address": "isengupt@ualberta.ca",
     "First Name": "Ishani",
-    "Last Name": "Sengupta",
-    "Email Address": "isengupt@ualberta.ca"
+    "Last Name": "Sengupta"
   },
   {
+    "Email Address": "sbutt@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sbutt@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jsohal@ualberta.ca",
     "First Name": "Jaspreet Kaur",
-    "Last Name": "Sohal",
-    "Email Address": "jsohal@ualberta.ca"
+    "Last Name": "Sohal"
   },
   {
+    "Email Address": "shuxin1@ualberta.ca",
     "First Name": "Shuxin",
-    "Last Name": "Chen",
-    "Email Address": "shuxin1@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "tkeyah@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tkeyah@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kalwani.aryan@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kalwani.aryan@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "hafsa@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hafsa@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "skhannan@me.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "skhannan@me.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "haodong6@ualberta.ca",
     "First Name": "Haodong",
-    "Last Name": "Wu",
-    "Email Address": "haodong6@ualberta.ca"
+    "Last Name": "Wu"
   },
   {
+    "Email Address": "amallon@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "amallon@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "makepeac@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "makepeac@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tomferedu@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tomferedu@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "salavawa@ualberta.ca",
     "First Name": "Cheryl",
-    "Last Name": "Walker",
-    "Email Address": "salavawa@ualberta.ca"
+    "Last Name": "Walker"
   },
   {
+    "Email Address": "bdupuis@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bdupuis@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "naviza@ualberta.ca",
     "First Name": "Richmond",
-    "Last Name": "Naviza",
-    "Email Address": "naviza@ualberta.ca"
+    "Last Name": "Naviza"
   },
   {
+    "Email Address": "lgopalka@umass.edu",
     "First Name": "LAKSHAY",
-    "Last Name": "GOPALKA",
-    "Email Address": "lgopalka@umass.edu"
+    "Last Name": "GOPALKA"
   },
   {
+    "Email Address": "psharvey@ualberta.ca",
     "First Name": "Patrick",
-    "Last Name": "Harvey",
-    "Email Address": "psharvey@ualberta.ca"
+    "Last Name": "Harvey"
   },
   {
+    "Email Address": "mabdulle@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mabdulle@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sraees@sfu.ca",
     "First Name": "Sumaiya",
-    "Last Name": "Raees",
-    "Email Address": "sraees@sfu.ca"
+    "Last Name": "Raees"
   },
   {
+    "Email Address": "zixiao2@ualberta.ca",
     "First Name": "Zixiao",
-    "Last Name": "Wang",
-    "Email Address": "zixiao2@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "truong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "truong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "batiuk@ualberta.ca",
     "First Name": "Noah",
-    "Last Name": "Batiuk",
-    "Email Address": "batiuk@ualberta.ca"
+    "Last Name": "Batiuk"
   },
   {
+    "Email Address": "rv.97ad@gmail.com",
     "First Name": "Rohan",
-    "Last Name": "Verma",
-    "Email Address": "rv.97ad@gmail.com"
+    "Last Name": "Verma"
   },
   {
+    "Email Address": "jennywlow@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jennywlow@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "fmuzongw@ualberta.ca",
     "First Name": "Faith",
-    "Last Name": "M",
-    "Email Address": "fmuzongw@ualberta.ca"
+    "Last Name": "M"
   },
   {
+    "Email Address": "w1564443949@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "w1564443949@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "zhengya2@ualberta.ca",
     "First Name": "Liu",
-    "Last Name": "zheng yang",
-    "Email Address": "zhengya2@ualberta.ca"
+    "Last Name": "zheng yang"
   },
   {
+    "Email Address": "mingxun@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mingxun@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "krishna.pulikotil@gmail.com",
     "First Name": "Krishna",
-    "Last Name": "P U",
-    "Email Address": "krishna.pulikotil@gmail.com"
+    "Last Name": "P U"
   },
   {
+    "Email Address": "zgaudry@ualberta.ca",
     "First Name": "Zoe",
-    "Last Name": "Gaudry",
-    "Email Address": "zgaudry@ualberta.ca"
+    "Last Name": "Gaudry"
   },
   {
+    "Email Address": "dsnoble@ualberta.ca",
     "First Name": "David",
-    "Last Name": "Snoble",
-    "Email Address": "dsnoble@ualberta.ca"
+    "Last Name": "Snoble"
   },
   {
+    "Email Address": "jamikhai@ualberta.ca",
     "First Name": "Justin",
-    "Last Name": "Mikhail",
-    "Email Address": "jamikhai@ualberta.ca"
+    "Last Name": "Mikhail"
   },
   {
+    "Email Address": "og@ualberta.ca",
     "First Name": "Jihoon",
-    "Last Name": "Og",
-    "Email Address": "og@ualberta.ca"
+    "Last Name": "Og"
   },
   {
+    "Email Address": "kathleenloisepescador@aol.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kathleenloisepescador@aol.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "truonggi@ualberta.ca",
     "First Name": "Truong-Giang",
-    "Last Name": "Pham",
-    "Email Address": "truonggi@ualberta.ca"
+    "Last Name": "Pham"
   },
   {
+    "Email Address": "sarah.wilson@gmail.com",
     "First Name": "Sarah",
-    "Last Name": "Wilson",
-    "Email Address": "sarah.wilson@gmail.com"
+    "Last Name": "Wilson"
   },
   {
+    "Email Address": "nhagerma@ualberta.ca",
     "First Name": "Nicole",
-    "Last Name": "Hagerman",
-    "Email Address": "nhagerma@ualberta.ca"
+    "Last Name": "Hagerman"
   },
   {
+    "Email Address": "doroteo@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "doroteo@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sapphirexixi@gmail.com",
     "First Name": "Xinya",
-    "Last Name": "Shan",
-    "Email Address": "sapphirexixi@gmail.com"
+    "Last Name": "Shan"
   },
   {
+    "Email Address": "cruzmart@ualberta.ca",
     "First Name": "Elisandro",
-    "Last Name": "Cruz Martinez",
-    "Email Address": "cruzmart@ualberta.ca"
+    "Last Name": "Cruz Martinez"
   },
   {
+    "Email Address": "aryaarun@ualberta.ca",
     "First Name": "Arya",
-    "Last Name": "Salunke",
-    "Email Address": "aryaarun@ualberta.ca"
+    "Last Name": "Salunke"
   },
   {
+    "Email Address": "jfhernan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jfhernan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jangani@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jangani@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "pdeepthi@vt.edu",
     "First Name": "Deepthi",
-    "Last Name": "Peri",
-    "Email Address": "pdeepthi@vt.edu"
+    "Last Name": "Peri"
   },
   {
+    "Email Address": "amod@ualberta.ca",
     "First Name": "Amod",
-    "Last Name": "Gautam",
-    "Email Address": "amod@ualberta.ca"
+    "Last Name": "Gautam"
   },
   {
+    "Email Address": "korym@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "korym@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ss1053@duke.edu",
     "First Name": "Shreenishkala",
-    "Last Name": "Sundar Raman",
-    "Email Address": "ss1053@duke.edu"
+    "Last Name": "Sundar Raman"
   },
   {
+    "Email Address": "wyou1@ualberta.ca",
     "First Name": "Wenhao",
-    "Last Name": "You",
-    "Email Address": "wyou1@ualberta.ca"
+    "Last Name": "You"
   },
   {
+    "Email Address": "nahin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nahin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "selwynle@ualberta.ca",
     "First Name": "Selwyn",
-    "Last Name": "Tamayo",
-    "Email Address": "selwynle@ualberta.ca"
+    "Last Name": "Tamayo"
   },
   {
+    "Email Address": "vardansaini13@gmail.com",
     "First Name": "Vardan",
-    "Last Name": "Saini",
-    "Email Address": "vardansaini13@gmail.com"
+    "Last Name": "Saini"
   },
   {
+    "Email Address": "davegoel29@gmail.com",
     "First Name": "Dave",
-    "Last Name": "Goel",
-    "Email Address": "davegoel29@gmail.com"
+    "Last Name": "Goel"
   },
   {
+    "Email Address": "kathleen.wheeler@alumni.ubc.ca",
     "First Name": "Kathleen",
-    "Last Name": "Wheeler",
-    "Email Address": "kathleen.wheeler@alumni.ubc.ca"
+    "Last Name": "Wheeler"
   },
   {
+    "Email Address": "alphonso@ualberta.ca",
     "First Name": "Alphonso",
-    "Last Name": "Dineros",
-    "Email Address": "alphonso@ualberta.ca"
+    "Last Name": "Dineros"
   },
   {
+    "Email Address": "eisha@ualberta.ca",
     "First Name": "Eisha",
-    "Last Name": "Ahmed",
-    "Email Address": "eisha@ualberta.ca"
+    "Last Name": "Ahmed"
   },
   {
+    "Email Address": "murali.shalini@gmail.com",
     "First Name": "Shalini",
-    "Last Name": "Tharuvai Murali",
-    "Email Address": "murali.shalini@gmail.com"
+    "Last Name": "Tharuvai Murali"
   },
   {
+    "Email Address": "amalik2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "amalik2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nobeldee@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nobeldee@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "larain@seas.upenn.edu",
     "First Name": "Laila",
-    "Last Name": "Arain",
-    "Email Address": "larain@seas.upenn.edu"
+    "Last Name": "Arain"
   },
   {
+    "Email Address": "crasta@ualberta.ca",
     "First Name": "Alisha",
-    "Last Name": "Crasta",
-    "Email Address": "crasta@ualberta.ca"
+    "Last Name": "Crasta"
   },
   {
+    "Email Address": "birm@ualberta.ca",
     "First Name": "Birm",
-    "Last Name": "Wais",
-    "Email Address": "birm@ualberta.ca"
+    "Last Name": "Wais"
   },
   {
+    "Email Address": "elee3@ualberta.ca",
     "First Name": "Eric",
-    "Last Name": "Lee",
-    "Email Address": "elee3@ualberta.ca"
+    "Last Name": "Lee"
   },
   {
+    "Email Address": "ltzhang@ualberta.ca",
     "First Name": "Larissa",
-    "Last Name": "Zhang",
-    "Email Address": "ltzhang@ualberta.ca"
+    "Last Name": "Zhang"
   },
   {
+    "Email Address": "hailan@ualberta.ca",
     "First Name": "Hailan",
-    "Last Name": "Xu",
-    "Email Address": "hailan@ualberta.ca"
+    "Last Name": "Xu"
   },
   {
+    "Email Address": "nicoledegrano@ualberta.ca",
     "First Name": "Nicole",
-    "Last Name": "De Grano",
-    "Email Address": "nicoledegrano@ualberta.ca"
+    "Last Name": "De Grano"
   },
   {
+    "Email Address": "amoh@ualberta.ca",
     "First Name": "Kobe",
-    "Last Name": "Amoh",
-    "Email Address": "amoh@ualberta.ca"
+    "Last Name": "Amoh"
   },
   {
+    "Email Address": "mullane@ualberta.ca",
     "First Name": "Grace",
-    "Last Name": "Mullane",
-    "Email Address": "mullane@ualberta.ca"
+    "Last Name": "Mullane"
   },
   {
+    "Email Address": "ridham1@ualberta.ca",
     "First Name": "Ridham",
-    "Last Name": "Patel",
-    "Email Address": "ridham1@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "turja.c16@gmail.com",
     "First Name": "Turja",
-    "Last Name": "Chowdhury",
-    "Email Address": "turja.c16@gmail.com"
+    "Last Name": "Chowdhury"
   },
   {
+    "Email Address": "nafisa@ualberta.ca",
     "First Name": "Nafisa",
-    "Last Name": "Hasan",
-    "Email Address": "nafisa@ualberta.ca"
+    "Last Name": "Hasan"
   },
   {
+    "Email Address": "vsalm@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "vsalm@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "massiva.mahamli@mail.mcgill.ca",
     "First Name": "Massy",
-    "Last Name": "Mahamli",
-    "Email Address": "massiva.mahamli@mail.mcgill.ca"
+    "Last Name": "Mahamli"
   },
   {
+    "Email Address": "garibsin@ualberta.ca",
     "First Name": "Jonathan",
-    "Last Name": "Garibsingh",
-    "Email Address": "garibsin@ualberta.ca"
+    "Last Name": "Garibsingh"
   },
   {
+    "Email Address": "qzuo@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qzuo@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "eivenlou@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "eivenlou@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yujui@ualberta.ca",
     "First Name": "Ray",
-    "Last Name": "Liu",
-    "Email Address": "yujui@ualberta.ca"
+    "Last Name": "Liu"
   },
   {
+    "Email Address": "pant1@ualberta.ca",
     "First Name": "Nishtha",
-    "Last Name": "Pant",
-    "Email Address": "pant1@ualberta.ca"
+    "Last Name": "Pant"
   },
   {
+    "Email Address": "fc1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "fc1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yanshan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yanshan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "agrawal.soumya@gmail.com",
     "First Name": "Soumya",
-    "Last Name": "Agrawal",
-    "Email Address": "agrawal.soumya@gmail.com"
+    "Last Name": "Agrawal"
   },
   {
+    "Email Address": "ferenc@ualberta.ca",
     "First Name": "Anita",
-    "Last Name": "Ferenc",
-    "Email Address": "ferenc@ualberta.ca"
+    "Last Name": "Ferenc"
   },
   {
+    "Email Address": "kuknur@ualberta.ca",
     "First Name": "Vedd",
-    "Last Name": "Kuknur",
-    "Email Address": "kuknur@ualberta.ca"
+    "Last Name": "Kuknur"
   },
   {
+    "Email Address": "ruijie@ualberta.ca",
     "First Name": "Ruijie",
-    "Last Name": "Li",
-    "Email Address": "ruijie@ualberta.ca"
+    "Last Name": "Li"
   },
   {
+    "Email Address": "dliu5@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "dliu5@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rystal.h@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rystal.h@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "dtrinh1@ualberta.ca",
     "First Name": "Derek",
-    "Last Name": "Trinh",
-    "Email Address": "dtrinh1@ualberta.ca"
+    "Last Name": "Trinh"
   },
   {
+    "Email Address": "vchuang@ualberta.ca",
     "First Name": "Vanessa",
-    "Last Name": "Huang",
-    "Email Address": "vchuang@ualberta.ca"
+    "Last Name": "Huang"
   },
   {
+    "Email Address": "kirtishanbhag@gmail.com",
     "First Name": "Kirti",
-    "Last Name": "Shanbhag",
-    "Email Address": "kirtishanbhag@gmail.com"
+    "Last Name": "Shanbhag"
   },
   {
+    "Email Address": "chuqing@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "chuqing@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mclaffer@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mclaffer@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "prerna.kapoorcs@gmail.com",
     "First Name": "Prerna",
-    "Last Name": "Kapoor",
-    "Email Address": "prerna.kapoorcs@gmail.com"
+    "Last Name": "Kapoor"
   },
   {
+    "Email Address": "ccastell@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ccastell@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kellytran@uchicago.edu",
     "First Name": "Kelly",
-    "Last Name": "Tran",
-    "Email Address": "kellytran@uchicago.edu"
+    "Last Name": "Tran"
   },
   {
+    "Email Address": "argho@ualberta.ca",
     "First Name": "Argho",
-    "Last Name": "Roy",
-    "Email Address": "argho@ualberta.ca"
+    "Last Name": "Roy"
   },
   {
+    "Email Address": "greshelwadhawan@gmail.com",
     "First Name": "Greshel",
-    "Last Name": "Wadhawan",
-    "Email Address": "greshelwadhawan@gmail.com"
+    "Last Name": "Wadhawan"
   },
   {
+    "Email Address": "hagi@ualberta.ca",
     "First Name": "Zubier",
-    "Last Name": "Hagi",
-    "Email Address": "hagi@ualberta.ca"
+    "Last Name": "Hagi"
   },
   {
+    "Email Address": "akriti.anand15@gmail.com",
     "First Name": "Akriti",
-    "Last Name": "Anand",
-    "Email Address": "akriti.anand15@gmail.com"
+    "Last Name": "Anand"
   },
   {
+    "Email Address": "macedote@ualberta.ca",
     "First Name": "Manuel",
-    "Last Name": "Macedo Teran",
-    "Email Address": "macedote@ualberta.ca"
+    "Last Name": "Macedo Teran"
   },
   {
+    "Email Address": "nwachukw@ualberta.ca",
     "First Name": "Favour",
-    "Last Name": "Nwachukwu",
-    "Email Address": "nwachukw@ualberta.ca"
+    "Last Name": "Nwachukwu"
   },
   {
+    "Email Address": "aizahasib@gmail.com",
     "First Name": "Aiza",
-    "Last Name": "Hasib",
-    "Email Address": "aizahasib@gmail.com"
+    "Last Name": "Hasib"
   },
   {
+    "Email Address": "mdhawan@ualberta.ca",
     "First Name": "Mahima",
-    "Last Name": "Dhawan",
-    "Email Address": "mdhawan@ualberta.ca"
+    "Last Name": "Dhawan"
   },
   {
+    "Email Address": "rani@colostate.edu",
     "First Name": "Nisha",
-    "Last Name": "Rani",
-    "Email Address": "rani@colostate.edu"
+    "Last Name": "Rani"
   },
   {
+    "Email Address": "seerden@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "seerden@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tglover@ualberta.ca",
     "First Name": "Tristen",
-    "Last Name": "Glover",
-    "Email Address": "tglover@ualberta.ca"
+    "Last Name": "Glover"
   },
   {
+    "Email Address": "thang@ualberta.ca",
     "First Name": "Thang",
-    "Last Name": "Chu",
-    "Email Address": "thang@ualberta.ca"
+    "Last Name": "Chu"
   },
   {
+    "Email Address": "wx5@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "wx5@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "stang5@ualberta.ca",
     "First Name": "Steven",
-    "Last Name": "Tang",
-    "Email Address": "stang5@ualberta.ca"
+    "Last Name": "Tang"
   },
   {
+    "Email Address": "Len3030@gmail.com",
     "First Name": "Len",
-    "Last Name": "Richter",
-    "Email Address": "Len3030@gmail.com"
+    "Last Name": "Richter"
   },
   {
+    "Email Address": "fariaswa@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "fariaswa@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kzb0086@auburn.edu",
     "First Name": "Kamand",
-    "Last Name": "Bagherian",
-    "Email Address": "kzb0086@auburn.edu"
+    "Last Name": "Bagherian"
   },
   {
+    "Email Address": "muidhadi@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "muidhadi@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "mm@idyll.io",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mm@idyll.io"
+    "Last Name": ""
   },
   {
+    "Email Address": "arakkals@ualberta.ca",
     "First Name": "Arakkal",
-    "Last Name": "Sooraj",
-    "Email Address": "arakkals@ualberta.ca"
+    "Last Name": "Sooraj"
   },
   {
+    "Email Address": "sadiaera12@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sadiaera12@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "kiara.gamroth@gmail.com",
     "First Name": "Kiara",
-    "Last Name": "",
-    "Email Address": "kiara.gamroth@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "esraa1@ualberta.ca",
     "First Name": "Esra'a",
-    "Last Name": "Saleh",
-    "Email Address": "esraa1@ualberta.ca"
+    "Last Name": "Saleh"
   },
   {
+    "Email Address": "zt2@ualberta.ca",
     "First Name": "Mason",
-    "Last Name": "Tien",
-    "Email Address": "zt2@ualberta.ca"
+    "Last Name": "Tien"
   },
   {
+    "Email Address": "pterse1@umd.edu",
     "First Name": "Puja",
-    "Last Name": "Terse",
-    "Email Address": "pterse1@umd.edu"
+    "Last Name": "Terse"
   },
   {
+    "Email Address": "omcleod@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "omcleod@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "pk200@duke.edu",
     "First Name": "Prerena",
-    "Last Name": "Prahlad",
-    "Email Address": "pk200@duke.edu"
+    "Last Name": "Prahlad"
   },
   {
+    "Email Address": "sheng.f@northeastern.edu",
     "First Name": "Fangfang",
-    "Last Name": "Sheng",
-    "Email Address": "sheng.f@northeastern.edu"
+    "Last Name": "Sheng"
   },
   {
+    "Email Address": "drishtijjain@gmail.com",
     "First Name": "Drishti",
-    "Last Name": "Jain",
-    "Email Address": "drishtijjain@gmail.com"
+    "Last Name": "Jain"
   },
   {
+    "Email Address": "reetikac9@gmail.com",
     "First Name": "Reetika",
-    "Last Name": "Chaudhary",
-    "Email Address": "reetikac9@gmail.com"
+    "Last Name": "Chaudhary"
   },
   {
+    "Email Address": "jcmartin@ualberta.ca",
     "First Name": "Jonathan",
-    "Last Name": "Martins",
-    "Email Address": "jcmartin@ualberta.ca"
+    "Last Name": "Martins"
   },
   {
+    "Email Address": "jothan@student.ubc.ca",
     "First Name": "Jonathan",
-    "Last Name": "Bergstrom",
-    "Email Address": "jothan@student.ubc.ca"
+    "Last Name": "Bergstrom"
   },
   {
+    "Email Address": "sunny2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sunny2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "Hannahwa@ualberta.ca",
     "First Name": "Hannah",
-    "Last Name": "Tellambura",
-    "Email Address": "Hannahwa@ualberta.ca"
+    "Last Name": "Tellambura"
   },
   {
+    "Email Address": "haoyu16@ualberta.ca",
     "First Name": "Haoyu",
-    "Last Name": "Zhang",
-    "Email Address": "haoyu16@ualberta.ca"
+    "Last Name": "Zhang"
   },
   {
+    "Email Address": "purnapus@ualberta.ca",
     "First Name": "Purnapushkala",
-    "Last Name": "Hariharan",
-    "Email Address": "purnapus@ualberta.ca"
+    "Last Name": "Hariharan"
   },
   {
+    "Email Address": "leusink@ualberta.ca",
     "First Name": "Amaris",
-    "Last Name": "Leusink",
-    "Email Address": "leusink@ualberta.ca"
+    "Last Name": "Leusink"
   },
   {
+    "Email Address": "sumitro@ualberta.ca",
     "First Name": "Armianto",
-    "Last Name": "Sumitro",
-    "Email Address": "sumitro@ualberta.ca"
+    "Last Name": "Sumitro"
   },
   {
+    "Email Address": "mkwok1@ualberta.ca",
     "First Name": "Michael",
-    "Last Name": "Kwok",
-    "Email Address": "mkwok1@ualberta.ca"
+    "Last Name": "Kwok"
   },
   {
+    "Email Address": "mvelmurugan@wisc.edu",
     "First Name": "Monniiesh",
-    "Last Name": "Velmurugan",
-    "Email Address": "mvelmurugan@wisc.edu"
+    "Last Name": "Velmurugan"
   },
   {
+    "Email Address": "cchen2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cchen2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "caitlyndeslauriers@gmail.com",
     "First Name": "Caitlyn",
-    "Last Name": "",
-    "Email Address": "caitlyndeslauriers@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "nansy.salem@edu.sait.ca",
     "First Name": "Nancy",
-    "Last Name": "Salem",
-    "Email Address": "nansy.salem@edu.sait.ca"
+    "Last Name": "Salem"
   },
   {
+    "Email Address": "babwany@ualberta.ca",
     "First Name": "Ayan",
-    "Last Name": "Babwany",
-    "Email Address": "babwany@ualberta.ca"
+    "Last Name": "Babwany"
   },
   {
+    "Email Address": "Beamin@ualberta.ca",
     "First Name": "Tarren",
-    "Last Name": "Beamin",
-    "Email Address": "Beamin@ualberta.ca"
+    "Last Name": "Beamin"
   },
   {
+    "Email Address": "dkh006@ucsd.edu",
     "First Name": "Brian",
-    "Last Name": "Han",
-    "Email Address": "dkh006@ucsd.edu"
+    "Last Name": "Han"
   },
   {
+    "Email Address": "alzafara@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "alzafara@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rubindra@ualberta.ca",
     "First Name": "Rubin",
-    "Last Name": "Selvarajan",
-    "Email Address": "rubindra@ualberta.ca"
+    "Last Name": "Selvarajan"
   },
   {
+    "Email Address": "jesmith@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jesmith@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jeev1isha@gmail.com",
     "First Name": "Jivisha",
-    "Last Name": "Kumar",
-    "Email Address": "jeev1isha@gmail.com"
+    "Last Name": "Kumar"
   },
   {
+    "Email Address": "jiayin7@ualberta.ca",
     "First Name": "Jiayin",
-    "Last Name": "He",
-    "Email Address": "jiayin7@ualberta.ca"
+    "Last Name": "He"
   },
   {
+    "Email Address": "eyc1@ualberta.ca",
     "First Name": "Katy",
-    "Last Name": "C",
-    "Email Address": "eyc1@ualberta.ca"
+    "Last Name": "C"
   },
   {
+    "Email Address": "irehmani@ualberta.ca",
     "First Name": "Ishaan",
-    "Last Name": "Rehmani",
-    "Email Address": "irehmani@ualberta.ca"
+    "Last Name": "Rehmani"
   },
   {
+    "Email Address": "cisnerom@gmail.com",
     "First Name": "Mariel",
-    "Last Name": "Cisneros",
-    "Email Address": "cisnerom@gmail.com"
+    "Last Name": "Cisneros"
   },
   {
+    "Email Address": "bangotti@ualberta.ca",
     "First Name": "Bianca",
-    "Last Name": "Angotti",
-    "Email Address": "bangotti@ualberta.ca"
+    "Last Name": "Angotti"
   },
   {
+    "Email Address": "sagikusmanov2002@gmail.com",
     "First Name": "Sagi",
-    "Last Name": "Kusmanov",
-    "Email Address": "sagikusmanov2002@gmail.com"
+    "Last Name": "Kusmanov"
   },
   {
+    "Email Address": "Skousbol@ualberta.ca",
     "First Name": "Emily",
-    "Last Name": "Skousbol",
-    "Email Address": "Skousbol@ualberta.ca"
+    "Last Name": "Skousbol"
   },
   {
+    "Email Address": "xxiang2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xxiang2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mirapatel2512@gmail.com",
     "First Name": "Mira",
-    "Last Name": "Patel",
-    "Email Address": "mirapatel2512@gmail.com"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "tsajed@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tsajed@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "bakshees@ualberta.ca",
     "First Name": "Baksheesh",
-    "Last Name": "Kaur",
-    "Email Address": "bakshees@ualberta.ca"
+    "Last Name": "Kaur"
   },
   {
+    "Email Address": "kartiinx@gmail.com",
     "First Name": "Karthika",
-    "Last Name": "A",
-    "Email Address": "kartiinx@gmail.com"
+    "Last Name": "A"
   },
   {
+    "Email Address": "bcleung@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bcleung@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "vashist@ualberta.ca",
     "First Name": "Neha",
-    "Last Name": "Vashist",
-    "Email Address": "vashist@ualberta.ca"
+    "Last Name": "Vashist"
   },
   {
+    "Email Address": "k27mehta@uwaterloo.ca",
     "First Name": "Kritika",
-    "Last Name": "Mehta",
-    "Email Address": "k27mehta@uwaterloo.ca"
+    "Last Name": "Mehta"
   },
   {
+    "Email Address": "okthatsit@gmail.com",
     "First Name": "Zander",
-    "Last Name": "Maxwell",
-    "Email Address": "okthatsit@gmail.com"
+    "Last Name": "Maxwell"
   },
   {
+    "Email Address": "dzhang4@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "dzhang4@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "seneshen@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "seneshen@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "igadani@ualberta.ca",
     "First Name": "Isha",
-    "Last Name": "Gadani",
-    "Email Address": "igadani@ualberta.ca"
+    "Last Name": "Gadani"
   },
   {
+    "Email Address": "martinezd7@mymacewan.ca",
     "First Name": "Dazznell",
-    "Last Name": "Martinez",
-    "Email Address": "martinezd7@mymacewan.ca"
+    "Last Name": "Martinez"
   },
   {
+    "Email Address": "patrick@gallworks.ca",
     "First Name": "Patrick",
-    "Last Name": "Gall",
-    "Email Address": "patrick@gallworks.ca"
+    "Last Name": "Gall"
   },
   {
+    "Email Address": "charellejazmin@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "charellejazmin@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "achawla@scu.edu",
     "First Name": "Aastha",
-    "Last Name": "Chawla",
-    "Email Address": "achawla@scu.edu"
+    "Last Name": "Chawla"
   },
   {
+    "Email Address": "niuy@uw.edu",
     "First Name": "Yanjie",
-    "Last Name": "Niu",
-    "Email Address": "niuy@uw.edu"
+    "Last Name": "Niu"
   },
   {
+    "Email Address": "yeonjae@ualberta.ca",
     "First Name": "Yeon-Jae",
-    "Last Name": "Jang",
-    "Email Address": "yeonjae@ualberta.ca"
+    "Last Name": "Jang"
   },
   {
+    "Email Address": "fbahri@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "fbahri@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hayleynicholl22@gmail.com",
     "First Name": "Hayley",
-    "Last Name": "",
-    "Email Address": "hayleynicholl22@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "hanasyk1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hanasyk1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jiabin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jiabin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "wajahat@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "wajahat@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rasoulpo@ualberta.ca",
     "First Name": "Rachel",
-    "Last Name": "Rasoulpour",
-    "Email Address": "rasoulpo@ualberta.ca"
+    "Last Name": "Rasoulpour"
   },
   {
+    "Email Address": "calgaryericl9@gmail.com",
     "First Name": "Eric",
-    "Last Name": "Lee",
-    "Email Address": "calgaryericl9@gmail.com"
+    "Last Name": "Lee"
   },
   {
+    "Email Address": "mye2@ualberta.ca",
     "First Name": "Ming",
-    "Last Name": "Ye",
-    "Email Address": "mye2@ualberta.ca"
+    "Last Name": "Ye"
   },
   {
+    "Email Address": "almokdad@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "almokdad@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yoh033@ucsd.edu",
     "First Name": "Yong-Yi",
-    "Last Name": "Hu",
-    "Email Address": "yoh033@ucsd.edu"
+    "Last Name": "Hu"
   },
   {
+    "Email Address": "ajaypart@ualberta.ca",
     "First Name": "Ajay",
-    "Last Name": "Gill",
-    "Email Address": "ajaypart@ualberta.ca"
+    "Last Name": "Gill"
   },
   {
+    "Email Address": "gtkahsay@ualberta.ca",
     "First Name": "Gelila",
-    "Last Name": "Kahsay",
-    "Email Address": "gtkahsay@ualberta.ca"
+    "Last Name": "Kahsay"
   },
   {
+    "Email Address": "wendy.zwd@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "wendy.zwd@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "keesha1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "keesha1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tstronac@ualberta.ca",
     "First Name": "Tim",
-    "Last Name": "Stronach",
-    "Email Address": "tstronac@ualberta.ca"
+    "Last Name": "Stronach"
   },
   {
+    "Email Address": "xzhang23@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xzhang23@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "vvyas1@ualberta.ca",
     "First Name": "Vedant",
-    "Last Name": "Vyas",
-    "Email Address": "vvyas1@ualberta.ca"
+    "Last Name": "Vyas"
   },
   {
+    "Email Address": "yalmuhta@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yalmuhta@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "potzelbe@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "potzelbe@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "pcheng1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "pcheng1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hyunseo@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hyunseo@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "fairouz@ualberta.ca",
     "First Name": "Fairouz",
-    "Last Name": "Tayem",
-    "Email Address": "fairouz@ualberta.ca"
+    "Last Name": "Tayem"
   },
   {
+    "Email Address": "lshang@ualberta.ca",
     "First Name": "Li",
-    "Last Name": "Shang",
-    "Email Address": "lshang@ualberta.ca"
+    "Last Name": "Shang"
   },
   {
+    "Email Address": "vishal.bhatnagar.14@gmail.com",
     "First Name": "Vishal",
-    "Last Name": "Bhatnagar",
-    "Email Address": "vishal.bhatnagar.14@gmail.com"
+    "Last Name": "Bhatnagar"
   },
   {
+    "Email Address": "ashwinsaxena47@gmail.com",
     "First Name": "Ashwin",
-    "Last Name": "Saxena",
-    "Email Address": "ashwinsaxena47@gmail.com"
+    "Last Name": "Saxena"
   },
   {
+    "Email Address": "azeen@ualberta.ca",
     "First Name": "Azeen",
-    "Last Name": "Murtaza",
-    "Email Address": "azeen@ualberta.ca"
+    "Last Name": "Murtaza"
   },
   {
+    "Email Address": "tnofstie@ualberta.ca",
     "First Name": "Taryn",
-    "Last Name": "Ofstie",
-    "Email Address": "tnofstie@ualberta.ca"
+    "Last Name": "Ofstie"
   },
   {
+    "Email Address": "husain3@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "husain3@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aileen.bui@outlook.com",
     "First Name": "Aileen",
-    "Last Name": "Bui",
-    "Email Address": "aileen.bui@outlook.com"
+    "Last Name": "Bui"
   },
   {
+    "Email Address": "ladanks@gmail.com",
     "First Name": "Ladan",
-    "Last Name": "Karimi",
-    "Email Address": "ladanks@gmail.com"
+    "Last Name": "Karimi"
   },
   {
+    "Email Address": "ohiwere@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ohiwere@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "Nmtraboulsi@gmail.com",
     "First Name": "Nicole",
-    "Last Name": "Traboulsi",
-    "Email Address": "Nmtraboulsi@gmail.com"
+    "Last Name": "Traboulsi"
   },
   {
+    "Email Address": "vahidzadeh.ehsan@gmail.com",
     "First Name": "Ehsan",
-    "Last Name": "Vahidzadeh",
-    "Email Address": "vahidzadeh.ehsan@gmail.com"
+    "Last Name": "Vahidzadeh"
   },
   {
+    "Email Address": "rafaello@ualberta.ca",
     "First Name": "Rafael",
-    "Last Name": "Pasion",
-    "Email Address": "rafaello@ualberta.ca"
+    "Last Name": "Pasion"
   },
   {
+    "Email Address": "chaerin@ualberta.ca",
     "First Name": "Anna",
-    "Last Name": "Song",
-    "Email Address": "chaerin@ualberta.ca"
+    "Last Name": "Song"
   },
   {
+    "Email Address": "rfeng2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rfeng2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jamesang@ualberta.ca",
     "First Name": "James",
-    "Last Name": "Te Eng Fo",
-    "Email Address": "jamesang@ualberta.ca"
+    "Last Name": "Te Eng Fo"
   },
   {
+    "Email Address": "malhotra@ualberta.ca",
     "First Name": "Vivek",
-    "Last Name": "Malhotra",
-    "Email Address": "malhotra@ualberta.ca"
+    "Last Name": "Malhotra"
   },
   {
+    "Email Address": "aprao@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aprao@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "elhanani@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "elhanani@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "lexie@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "lexie@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "fattah@ualberta.ca",
     "First Name": "Tauseef Nafee",
-    "Last Name": "Fattah",
-    "Email Address": "fattah@ualberta.ca"
+    "Last Name": "Fattah"
   },
   {
+    "Email Address": "wlu4@ualberta.ca",
     "First Name": "Wentao",
-    "Last Name": "Lu",
-    "Email Address": "wlu4@ualberta.ca"
+    "Last Name": "Lu"
   },
   {
+    "Email Address": "yue2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yue2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dlothian@ualberta.ca",
     "First Name": "Delaney",
-    "Last Name": "Lothian",
-    "Email Address": "dlothian@ualberta.ca"
+    "Last Name": "Lothian"
   },
   {
+    "Email Address": "mmtahir@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mmtahir@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mihilsan@ualberta.ca",
     "First Name": "Mihil",
-    "Last Name": "Patel",
-    "Email Address": "mihilsan@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "jdvanden@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jdvanden@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "elamy1@ualberta.ca",
     "First Name": "Adam",
-    "Last Name": "Elamy",
-    "Email Address": "elamy1@ualberta.ca"
+    "Last Name": "Elamy"
   },
   {
+    "Email Address": "dble@ualberta.ca",
     "First Name": "Diana",
-    "Last Name": "Le",
-    "Email Address": "dble@ualberta.ca"
+    "Last Name": "Le"
   },
   {
+    "Email Address": "jessica.coulombe4@gmail.com",
     "First Name": "Jessica",
-    "Last Name": "Coulombe",
-    "Email Address": "jessica.coulombe4@gmail.com"
+    "Last Name": "Coulombe"
   },
   {
+    "Email Address": "shehraj@ualberta.ca",
     "First Name": "Shehraj",
-    "Last Name": "Singh",
-    "Email Address": "shehraj@ualberta.ca"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "mailanjana.krish@gmail.com",
     "First Name": "Anjana",
-    "Last Name": "Krishnamurthi",
-    "Email Address": "mailanjana.krish@gmail.com"
+    "Last Name": "Krishnamurthi"
   },
   {
+    "Email Address": "writepep@yahoo.com",
     "First Name": "Ilobekemen Perpetual",
-    "Last Name": "Oladoja",
-    "Email Address": "writepep@yahoo.com"
+    "Last Name": "Oladoja"
   },
   {
+    "Email Address": "flandorf@ualberta.ca",
     "First Name": "Mihaly",
-    "Last Name": "Flandorffer",
-    "Email Address": "flandorf@ualberta.ca"
+    "Last Name": "Flandorffer"
   },
   {
+    "Email Address": "sacro@ualberta.ca",
     "First Name": "Daniel",
-    "Last Name": "Sacro",
-    "Email Address": "sacro@ualberta.ca"
+    "Last Name": "Sacro"
   },
   {
+    "Email Address": "swastik@ualberta.ca",
     "First Name": "Swastik",
-    "Last Name": "Sharma",
-    "Email Address": "swastik@ualberta.ca"
+    "Last Name": "Sharma"
   },
   {
+    "Email Address": "yaser@ualberta.ca",
     "First Name": "Yaser",
-    "Last Name": "Ibrahim",
-    "Email Address": "yaser@ualberta.ca"
+    "Last Name": "Ibrahim"
   },
   {
+    "Email Address": "preethimukundan1295@gmail.com",
     "First Name": "Preethi",
-    "Last Name": "Mukundan",
-    "Email Address": "preethimukundan1295@gmail.com"
+    "Last Name": "Mukundan"
   },
   {
+    "Email Address": "sdavis1@ualberta.ca",
     "First Name": "Sarah",
-    "Last Name": "Davis",
-    "Email Address": "sdavis1@ualberta.ca"
+    "Last Name": "Davis"
   },
   {
+    "Email Address": "btung1@ualberta.ca",
     "First Name": "Byron",
-    "Last Name": "Tung",
-    "Email Address": "btung1@ualberta.ca"
+    "Last Name": "Tung"
   },
   {
+    "Email Address": "tania.manhas@tamu.edu",
     "First Name": "Tania",
-    "Last Name": "Manhas",
-    "Email Address": "tania.manhas@tamu.edu"
+    "Last Name": "Manhas"
   },
   {
+    "Email Address": "hreherch@ualberta.ca",
     "First Name": "Bennet",
-    "Last Name": "Hreherchuk",
-    "Email Address": "hreherch@ualberta.ca"
+    "Last Name": "Hreherchuk"
   },
   {
+    "Email Address": "reez.a@northeastern.edu",
     "First Name": "Aleesha",
-    "Last Name": "Reez",
-    "Email Address": "reez.a@northeastern.edu"
+    "Last Name": "Reez"
   },
   {
+    "Email Address": "aheal@ualberta.ca",
     "First Name": "Ayden",
-    "Last Name": "Heal",
-    "Email Address": "aheal@ualberta.ca"
+    "Last Name": "Heal"
   },
   {
+    "Email Address": "samadhiranatunga@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "samadhiranatunga@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "himanshis.25@gmail.com",
     "First Name": "Himanshi",
-    "Last Name": "Shrivastava",
-    "Email Address": "himanshis.25@gmail.com"
+    "Last Name": "Shrivastava"
   },
   {
+    "Email Address": "inssia.ahmed@gmail.com",
     "First Name": "Inssia",
-    "Last Name": "Ahmed",
-    "Email Address": "inssia.ahmed@gmail.com"
+    "Last Name": "Ahmed"
   },
   {
+    "Email Address": "pyousefi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "pyousefi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sa3763@columbia.edu",
     "First Name": "Shreya",
-    "Last Name": "Agrawal",
-    "Email Address": "sa3763@columbia.edu"
+    "Last Name": "Agrawal"
   },
   {
+    "Email Address": "amwhitta@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "amwhitta@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "amanda6@ualberta.ca",
     "First Name": "Amanda",
-    "Last Name": "Nguyen",
-    "Email Address": "amanda6@ualberta.ca"
+    "Last Name": "Nguyen"
   },
   {
+    "Email Address": "riona@ualberta.ca",
     "First Name": "Riona",
-    "Last Name": "Wiberg",
-    "Email Address": "riona@ualberta.ca"
+    "Last Name": "Wiberg"
   },
   {
+    "Email Address": "inioluwa@ualberta.ca",
     "First Name": "Inioluwa",
-    "Last Name": "Adeniyi",
-    "Email Address": "inioluwa@ualberta.ca"
+    "Last Name": "Adeniyi"
   },
   {
+    "Email Address": "hlin2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hlin2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "davidhan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "davidhan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "eazizika@sfu.ca",
     "First Name": "Elmira",
-    "Last Name": "Azizi",
-    "Email Address": "eazizika@sfu.ca"
+    "Last Name": "Azizi"
   },
   {
+    "Email Address": "rishikagupta0006@gmail.com",
     "First Name": "Rishika",
-    "Last Name": "Gupta",
-    "Email Address": "rishikagupta0006@gmail.com"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "ariannesoumahoro@gmail.com",
     "First Name": "Myriame",
-    "Last Name": "Soumahoro",
-    "Email Address": "ariannesoumahoro@gmail.com"
+    "Last Name": "Soumahoro"
   },
   {
+    "Email Address": "alexandercai@outlook.com",
     "First Name": "Alexander",
-    "Last Name": "Cai",
-    "Email Address": "alexandercai@outlook.com"
+    "Last Name": "Cai"
   },
   {
+    "Email Address": "salahako@ualberta.ca",
     "First Name": "Shamika",
-    "Last Name": "Alahakoon",
-    "Email Address": "salahako@ualberta.ca"
+    "Last Name": "Alahakoon"
   },
   {
+    "Email Address": "jv1340@nyu.edu",
     "First Name": "Jahnavi",
-    "Last Name": "Vyas",
-    "Email Address": "jv1340@nyu.edu"
+    "Last Name": "Vyas"
   },
   {
+    "Email Address": "cao4@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cao4@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "darsh121999@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "darsh121999@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "candelario.gtz@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "candelario.gtz@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "amir2@ualberta.ca",
     "First Name": "Abeer",
-    "Last Name": "Waheed",
-    "Email Address": "amir2@ualberta.ca"
+    "Last Name": "Waheed"
   },
   {
+    "Email Address": "yteng4@ualberta.ca",
     "First Name": "Yu",
-    "Last Name": "Teng",
-    "Email Address": "yteng4@ualberta.ca"
+    "Last Name": "Teng"
   },
   {
+    "Email Address": "rahulpre@ualberta.ca",
     "First Name": "Rahulpreet",
-    "Last Name": "Bal",
-    "Email Address": "rahulpre@ualberta.ca"
+    "Last Name": "Bal"
   },
   {
+    "Email Address": "ckennedy@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ckennedy@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "brandonfiogbe@gmail.com",
     "First Name": "Brandon",
-    "Last Name": "Fiogbe",
-    "Email Address": "brandonfiogbe@gmail.com"
+    "Last Name": "Fiogbe"
   },
   {
+    "Email Address": "nadeen@ualberta.ca",
     "First Name": "Nadeen",
-    "Last Name": "Mohamed",
-    "Email Address": "nadeen@ualberta.ca"
+    "Last Name": "Mohamed"
   },
   {
+    "Email Address": "yashjotm@gmail.com",
     "First Name": "Yash",
-    "Last Name": "Multani",
-    "Email Address": "yashjotm@gmail.com"
+    "Last Name": "Multani"
   },
   {
+    "Email Address": "asbutt@ualberta.ca",
     "First Name": "Asfandyar",
-    "Last Name": "Butt",
-    "Email Address": "asbutt@ualberta.ca"
+    "Last Name": "Butt"
   },
   {
+    "Email Address": "ms15@ualberta.ca",
     "First Name": "Manpreet",
-    "Last Name": "Singh",
-    "Email Address": "ms15@ualberta.ca"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "sadel@ualberta.ca",
     "First Name": "Amir",
-    "Last Name": "Adel",
-    "Email Address": "sadel@ualberta.ca"
+    "Last Name": "Adel"
   },
   {
+    "Email Address": "gurveers@ualberta.ca",
     "First Name": "Gurveer Singh",
-    "Last Name": "Sohal",
-    "Email Address": "gurveers@ualberta.ca"
+    "Last Name": "Sohal"
   },
   {
+    "Email Address": "vivianliwang8@gmail.com",
     "First Name": "Vivian",
-    "Last Name": "Li",
-    "Email Address": "vivianliwang8@gmail.com"
+    "Last Name": "Li"
   },
   {
+    "Email Address": "yche1@ualberta.ca",
     "First Name": "Sylvia",
-    "Last Name": "C he",
-    "Email Address": "yche1@ualberta.ca"
+    "Last Name": "C he"
   },
   {
+    "Email Address": "shebbar@ualberta.ca",
     "First Name": "Shreyank",
-    "Last Name": "Hebbar",
-    "Email Address": "shebbar@ualberta.ca"
+    "Last Name": "Hebbar"
   },
   {
+    "Email Address": "emcdonal@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "emcdonal@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "merilie@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "merilie@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aholgate@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aholgate@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "npate285@uwo.ca",
     "First Name": "Nikita",
-    "Last Name": "Patel",
-    "Email Address": "npate285@uwo.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "sean.oyler@gmail.com",
     "First Name": "Sean",
-    "Last Name": "Oyler",
-    "Email Address": "sean.oyler@gmail.com"
+    "Last Name": "Oyler"
   },
   {
+    "Email Address": "limandy00@gmail.com",
     "First Name": "Mandy",
-    "Last Name": "Li",
-    "Email Address": "limandy00@gmail.com"
+    "Last Name": "Li"
   },
   {
+    "Email Address": "raissa@ualberta.ca",
     "First Name": "Rai",
-    "Last Name": "Bedural",
-    "Email Address": "raissa@ualberta.ca"
+    "Last Name": "Bedural"
   },
   {
+    "Email Address": "raunak1@ualberta.ca",
     "First Name": "Raunak",
-    "Last Name": "Agarwal",
-    "Email Address": "raunak1@ualberta.ca"
+    "Last Name": "Agarwal"
   },
   {
+    "Email Address": "karl.driver@manpower.com",
     "First Name": "Karl",
-    "Last Name": "Driver",
-    "Email Address": "karl.driver@manpower.com"
+    "Last Name": "Driver"
   },
   {
+    "Email Address": "yu.michelle97@gmail.com",
     "First Name": "Michelle",
-    "Last Name": "Yu",
-    "Email Address": "yu.michelle97@gmail.com"
+    "Last Name": "Yu"
   },
   {
+    "Email Address": "kpendry@uaberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kpendry@uaberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "laina.vanderwell@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "laina.vanderwell@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "denby@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "denby@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jnji@ualberta.ca",
     "First Name": "Joshua",
-    "Last Name": "Ji",
-    "Email Address": "jnji@ualberta.ca"
+    "Last Name": "Ji"
   },
   {
+    "Email Address": "kirti.shanbhag@sjsu.edu",
     "First Name": "Kirti",
-    "Last Name": "Shanbhag",
-    "Email Address": "kirti.shanbhag@sjsu.edu"
+    "Last Name": "Shanbhag"
   },
   {
+    "Email Address": "meinders@ualberta.ca",
     "First Name": "Mandy",
-    "Last Name": "Meindersma",
-    "Email Address": "meinders@ualberta.ca"
+    "Last Name": "Meindersma"
   },
   {
+    "Email Address": "ssehrawa@ualberta.ca",
     "First Name": "Shubhangi",
-    "Last Name": "Sehrawat",
-    "Email Address": "ssehrawa@ualberta.ca"
+    "Last Name": "Sehrawat"
   },
   {
+    "Email Address": "bhruguni@ualberta.ca",
     "First Name": "Bhrugu Nilesh",
-    "Last Name": "Rajput",
-    "Email Address": "bhruguni@ualberta.ca"
+    "Last Name": "Rajput"
   },
   {
+    "Email Address": "amroaman@hotmail.com",
     "First Name": "Amro",
-    "Last Name": "Amanuddein",
-    "Email Address": "amroaman@hotmail.com"
+    "Last Name": "Amanuddein"
   },
   {
+    "Email Address": "clare2@ualberta.ca",
     "First Name": "Clare",
-    "Last Name": "Chen",
-    "Email Address": "clare2@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "caherne@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "caherne@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ankush4@ualberta.ca",
     "First Name": "Ankush",
-    "Last Name": "Singh",
-    "Email Address": "ankush4@ualberta.ca"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "poonamku@buffalo.edu",
     "First Name": "Poonam",
-    "Last Name": "Kumari",
-    "Email Address": "poonamku@buffalo.edu"
+    "Last Name": "Kumari"
   },
   {
+    "Email Address": "tauseefnafee@gmail.com",
     "First Name": "Tauseef Nafee",
-    "Last Name": "Fattah",
-    "Email Address": "tauseefnafee@gmail.com"
+    "Last Name": "Fattah"
   },
   {
+    "Email Address": "b.mathur@share.epsb.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "b.mathur@share.epsb.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "amaan2@ualberta.ca",
     "First Name": "Amaan",
-    "Last Name": "Mohammed",
-    "Email Address": "amaan2@ualberta.ca"
+    "Last Name": "Mohammed"
   },
   {
+    "Email Address": "xinmeng1@ualberta.ca",
     "First Name": "Xinmeng",
-    "Last Name": "",
-    "Email Address": "xinmeng1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aaross@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aaross@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "olivia.s.zheng@gmail.com",
     "First Name": "Olivia",
-    "Last Name": "",
-    "Email Address": "olivia.s.zheng@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "jiahui18@ualberta.ca",
     "First Name": "Jiahui",
-    "Last Name": "Liu",
-    "Email Address": "jiahui18@ualberta.ca"
+    "Last Name": "Liu"
   },
   {
+    "Email Address": "utsha@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "utsha@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "seunghee@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "seunghee@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "johann.b@telus.net",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "johann.b@telus.net"
+    "Last Name": ""
   },
   {
+    "Email Address": "arnobmallik@gmail.com",
     "First Name": "Arnob",
-    "Last Name": "Malik",
-    "Email Address": "arnobmallik@gmail.com"
+    "Last Name": "Malik"
   },
   {
+    "Email Address": "lpugh@ualberta.ca",
     "First Name": "Landyn",
-    "Last Name": "Pugh",
-    "Email Address": "lpugh@ualberta.ca"
+    "Last Name": "Pugh"
   },
   {
+    "Email Address": "cdaryani@ualberta.ca",
     "First Name": "Chirag",
-    "Last Name": "Daryani",
-    "Email Address": "cdaryani@ualberta.ca"
+    "Last Name": "Daryani"
   },
   {
+    "Email Address": "dallan@ualberta.ca",
     "First Name": "Dillon",
-    "Last Name": "Allan",
-    "Email Address": "dallan@ualberta.ca"
+    "Last Name": "Allan"
   },
   {
+    "Email Address": "zhininghjl@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "zhininghjl@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "mehtacharmi99@gmail.com",
     "First Name": "Charmi",
-    "Last Name": "Mehta",
-    "Email Address": "mehtacharmi99@gmail.com"
+    "Last Name": "Mehta"
   },
   {
+    "Email Address": "zzhou3@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "zzhou3@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mishra2@ualberta.ca",
     "First Name": "Aniket",
-    "Last Name": "Mishra",
-    "Email Address": "mishra2@ualberta.ca"
+    "Last Name": "Mishra"
   },
   {
+    "Email Address": "demcknig@ualberta.ca",
     "First Name": "Dawn",
-    "Last Name": "McKnight",
-    "Email Address": "demcknig@ualberta.ca"
+    "Last Name": "McKnight"
   },
   {
+    "Email Address": "humanita@ualberta.ca",
     "First Name": "Della",
-    "Last Name": "Humanita",
-    "Email Address": "humanita@ualberta.ca"
+    "Last Name": "Humanita"
   },
   {
+    "Email Address": "muneer1@ualberta.ca",
     "First Name": "Almer",
-    "Last Name": "Muneer",
-    "Email Address": "muneer1@ualberta.ca"
+    "Last Name": "Muneer"
   },
   {
+    "Email Address": "cching@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cching@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "guptapoonam212@gmail.com",
     "First Name": "Poonam",
-    "Last Name": "Gupta",
-    "Email Address": "guptapoonam212@gmail.com"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "mzuniga@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mzuniga@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sollazzo@ualberta.ca",
     "First Name": "Anna",
-    "Last Name": "Sollazzo",
-    "Email Address": "sollazzo@ualberta.ca"
+    "Last Name": "Sollazzo"
   },
   {
+    "Email Address": "wpeterso@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "wpeterso@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "haroldagbulu@gmail.com",
     "First Name": "Harold",
-    "Last Name": "Agbulu",
-    "Email Address": "haroldagbulu@gmail.com"
+    "Last Name": "Agbulu"
   },
   {
+    "Email Address": "sarvaiya@ualberta.ca",
     "First Name": "Harsh",
-    "Last Name": "Sarvaiya",
-    "Email Address": "sarvaiya@ualberta.ca"
+    "Last Name": "Sarvaiya"
   },
   {
+    "Email Address": "ckalutycz@gmail.com",
     "First Name": "Charlotte",
-    "Last Name": "Kalutycz",
-    "Email Address": "ckalutycz@gmail.com"
+    "Last Name": "Kalutycz"
   },
   {
+    "Email Address": "Fairy.Gandhi@colorado.edu",
     "First Name": "Fairy",
-    "Last Name": "Gandhi",
-    "Email Address": "Fairy.Gandhi@colorado.edu"
+    "Last Name": "Gandhi"
   },
   {
+    "Email Address": "bos@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bos@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nahinchowdhury4@gmail.com",
     "First Name": "Nahin Aziz",
-    "Last Name": "Chowdhury",
-    "Email Address": "nahinchowdhury4@gmail.com"
+    "Last Name": "Chowdhury"
   },
   {
+    "Email Address": "ha10@ualberta.ca",
     "First Name": "Hancheng",
-    "Last Name": "Wu",
-    "Email Address": "ha10@ualberta.ca"
+    "Last Name": "Wu"
   },
   {
+    "Email Address": "hayward@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hayward@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ntang@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ntang@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "anahita3@ualberta.ca",
     "First Name": "Anahita",
-    "Last Name": "Gupta",
-    "Email Address": "anahita3@ualberta.ca"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "jose.barrios@hootsuite.com",
     "First Name": "Jose",
-    "Last Name": "Barrios",
-    "Email Address": "jose.barrios@hootsuite.com"
+    "Last Name": "Barrios"
   },
   {
+    "Email Address": "najibatr@ualberta.ca",
     "First Name": "Raya",
-    "Last Name": "Najiba Troyee",
-    "Email Address": "najibatr@ualberta.ca"
+    "Last Name": "Najiba Troyee"
   },
   {
+    "Email Address": "yhu7@ualberta.ca",
     "First Name": "Bruce",
-    "Last Name": "Hu",
-    "Email Address": "yhu7@ualberta.ca"
+    "Last Name": "Hu"
   },
   {
+    "Email Address": "jenny5@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jenny5@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "lconn.hba2022@ivey.ca",
     "First Name": "Leland",
-    "Last Name": "Conn",
-    "Email Address": "lconn.hba2022@ivey.ca"
+    "Last Name": "Conn"
   },
   {
+    "Email Address": "banh.shally@gmail.com",
     "First Name": "Shally",
-    "Last Name": "Banh",
-    "Email Address": "banh.shally@gmail.com"
+    "Last Name": "Banh"
   },
   {
+    "Email Address": "cyang13@ualberta.ca",
     "First Name": "Chen",
-    "Last Name": "Yang",
-    "Email Address": "cyang13@ualberta.ca"
+    "Last Name": "Yang"
   },
   {
+    "Email Address": "m_jahanr@live.concordia.ca",
     "First Name": "Mohammad Ishfaque",
-    "Last Name": "Jahan Rafee",
-    "Email Address": "m_jahanr@live.concordia.ca"
+    "Last Name": "Jahan Rafee"
   },
   {
+    "Email Address": "akoop@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "akoop@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "vsilva@ualberta.ca",
     "First Name": "Victor",
-    "Last Name": "Silva",
-    "Email Address": "vsilva@ualberta.ca"
+    "Last Name": "Silva"
   },
   {
+    "Email Address": "mikal.m.kotadia@gmail.com",
     "First Name": "Mikal",
-    "Last Name": "Kotadia",
-    "Email Address": "mikal.m.kotadia@gmail.com"
+    "Last Name": "Kotadia"
   },
   {
+    "Email Address": "yuanxi1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yuanxi1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "maarij1@ualberta.ca",
     "First Name": "Maarij",
-    "Last Name": "Khan",
-    "Email Address": "maarij1@ualberta.ca"
+    "Last Name": "Khan"
   },
   {
+    "Email Address": "buniel@ualberta.ca",
     "First Name": "Clarisse",
-    "Last Name": "Buniel",
-    "Email Address": "buniel@ualberta.ca"
+    "Last Name": "Buniel"
   },
   {
+    "Email Address": "payas@ualberta.ca",
     "First Name": "Payas",
-    "Last Name": "Singh",
-    "Email Address": "payas@ualberta.ca"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "srilaxmi.balakrishnan@marylandsmith.umd.edu",
     "First Name": "Srilaxmi",
-    "Last Name": "Balakrishnan",
-    "Email Address": "srilaxmi.balakrishnan@marylandsmith.umd.edu"
+    "Last Name": "Balakrishnan"
   },
   {
+    "Email Address": "huisu@ualberta.ca",
     "First Name": "Huisu",
-    "Last Name": "Kim",
-    "Email Address": "huisu@ualberta.ca"
+    "Last Name": "Kim"
   },
   {
+    "Email Address": "jessbrownell09@gmail.com",
     "First Name": "Jessica",
-    "Last Name": "Brownell",
-    "Email Address": "jessbrownell09@gmail.com"
+    "Last Name": "Brownell"
   },
   {
+    "Email Address": "aggrawalsakhi26@gmail.com",
     "First Name": "Sakhi",
-    "Last Name": "Aggrawal",
-    "Email Address": "aggrawalsakhi26@gmail.com"
+    "Last Name": "Aggrawal"
   },
   {
+    "Email Address": "jianle@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jianle@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nicokai6666@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nicokai6666@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "tntran1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tntran1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sjodin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sjodin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rverma3@ualberta.ca",
     "First Name": "Rohan",
-    "Last Name": "Verma",
-    "Email Address": "rverma3@ualberta.ca"
+    "Last Name": "Verma"
   },
   {
+    "Email Address": "ninahamidli@minerva.kgi.edu",
     "First Name": "Nina",
-    "Last Name": "Hamidli",
-    "Email Address": "ninahamidli@minerva.kgi.edu"
+    "Last Name": "Hamidli"
   },
   {
+    "Email Address": "samia_krid@hotmail.com",
     "First Name": "Samia",
-    "Last Name": "Krid",
-    "Email Address": "samia_krid@hotmail.com"
+    "Last Name": "Krid"
   },
   {
+    "Email Address": "andyalmonte8@gmail.com",
     "First Name": "Sandra",
-    "Last Name": "Almonte",
-    "Email Address": "andyalmonte8@gmail.com"
+    "Last Name": "Almonte"
   },
   {
+    "Email Address": "jessly2121@gmail.com",
     "First Name": "Jessica",
-    "Last Name": "Yan",
-    "Email Address": "jessly2121@gmail.com"
+    "Last Name": "Yan"
   },
   {
+    "Email Address": "jmbrando@ualberta.ca",
     "First Name": "Janet",
-    "Last Name": "Brandon",
-    "Email Address": "jmbrando@ualberta.ca"
+    "Last Name": "Brandon"
   },
   {
+    "Email Address": "junyan4@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "junyan4@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jkhennig@ualberta.ca",
     "First Name": "Jake",
-    "Last Name": "Hennig",
-    "Email Address": "jkhennig@ualberta.ca"
+    "Last Name": "Hennig"
   },
   {
+    "Email Address": "faiyaz1@ualberta.ca",
     "First Name": "Faiyaz",
-    "Last Name": "Ahmed",
-    "Email Address": "faiyaz1@ualberta.ca"
+    "Last Name": "Ahmed"
   },
   {
+    "Email Address": "atitus@ualberta.ca",
     "First Name": "Ashish",
-    "Last Name": "Titus",
-    "Email Address": "atitus@ualberta.ca"
+    "Last Name": "Titus"
   },
   {
+    "Email Address": "am8@ualberta.ca",
     "First Name": "Abdullah",
-    "Last Name": "Mohammed",
-    "Email Address": "am8@ualberta.ca"
+    "Last Name": "Mohammed"
   },
   {
+    "Email Address": "xwen2@ualberta.ca",
     "First Name": "Xuerui",
-    "Last Name": "Wen",
-    "Email Address": "xwen2@ualberta.ca"
+    "Last Name": "Wen"
   },
   {
+    "Email Address": "jianna.caronan@rutgers.edu",
     "First Name": "Jianna",
-    "Last Name": "Caronan",
-    "Email Address": "jianna.caronan@rutgers.edu"
+    "Last Name": "Caronan"
   },
   {
+    "Email Address": "jwhite5@iwu.edu",
     "First Name": "Jasmine",
-    "Last Name": "White",
-    "Email Address": "jwhite5@iwu.edu"
+    "Last Name": "White"
   },
   {
+    "Email Address": "hermanto@ualberta.ca",
     "First Name": "Fiona",
-    "Last Name": "Hermanto",
-    "Email Address": "hermanto@ualberta.ca"
+    "Last Name": "Hermanto"
   },
   {
+    "Email Address": "emmac18@student.ubc.ca",
     "First Name": "Emma",
-    "Last Name": "Cavacuiti",
-    "Email Address": "emmac18@student.ubc.ca"
+    "Last Name": "Cavacuiti"
   },
   {
+    "Email Address": "hajong@uaberta.ca",
     "First Name": "Hajong",
-    "Last Name": "Kim",
-    "Email Address": "hajong@uaberta.ca"
+    "Last Name": "Kim"
   },
   {
+    "Email Address": "smh1@ualberta.ca",
     "First Name": "Stuart",
-    "Last Name": "Hamilton",
-    "Email Address": "smh1@ualberta.ca"
+    "Last Name": "Hamilton"
   },
   {
+    "Email Address": "zyu6@ualberta.ca",
     "First Name": "Zhiyuan",
-    "Last Name": "Yu",
-    "Email Address": "zyu6@ualberta.ca"
+    "Last Name": "Yu"
   },
   {
+    "Email Address": "sclimaco@ualberta.ca",
     "First Name": "Sarah",
-    "Last Name": "Climaco",
-    "Email Address": "sclimaco@ualberta.ca"
+    "Last Name": "Climaco"
   },
   {
+    "Email Address": "weitong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "weitong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "adekar@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "adekar@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yanzhu1@ualberta.ca",
     "First Name": "Penelope",
-    "Last Name": "Chen",
-    "Email Address": "yanzhu1@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "fi1@ualberta.ca",
     "First Name": "Fatima",
-    "Last Name": "Ibrahim",
-    "Email Address": "fi1@ualberta.ca"
+    "Last Name": "Ibrahim"
   },
   {
+    "Email Address": "mendo151@cougars.csusm.edu",
     "First Name": "Neala",
-    "Last Name": "Mendoza",
-    "Email Address": "mendo151@cougars.csusm.edu"
+    "Last Name": "Mendoza"
   },
   {
+    "Email Address": "cwang19@ualberta.ca",
     "First Name": "Chen",
-    "Last Name": "Wang",
-    "Email Address": "cwang19@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "mughalmaheen3@gmail.com",
     "First Name": "Maheen",
-    "Last Name": "Mughal",
-    "Email Address": "mughalmaheen3@gmail.com"
+    "Last Name": "Mughal"
   },
   {
+    "Email Address": "balisnom@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "balisnom@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "evidorsch@gmail.com",
     "First Name": "Evi",
-    "Last Name": "",
-    "Email Address": "evidorsch@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "gslam@stanford.edu",
     "First Name": "Grace",
-    "Last Name": "Lam",
-    "Email Address": "gslam@stanford.edu"
+    "Last Name": "Lam"
   },
   {
+    "Email Address": "sutanshu@ualberta.ca",
     "First Name": "Sutanshu",
-    "Last Name": "Seth",
-    "Email Address": "sutanshu@ualberta.ca"
+    "Last Name": "Seth"
   },
   {
+    "Email Address": "devinajaiswal98@gmail.com",
     "First Name": "Devina",
-    "Last Name": "Jaiswal",
-    "Email Address": "devinajaiswal98@gmail.com"
+    "Last Name": "Jaiswal"
   },
   {
+    "Email Address": "zw2@ualberta.ca",
     "First Name": "Zixuan",
-    "Last Name": "Wang",
-    "Email Address": "zw2@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "vanmaren@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "vanmaren@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kesh.moonian@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kesh.moonian@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "cziegler@ualberta.ca",
     "First Name": "Carlin",
-    "Last Name": "Ziegler",
-    "Email Address": "cziegler@ualberta.ca"
+    "Last Name": "Ziegler"
   },
   {
+    "Email Address": "rv4bk@virginia.edu",
     "First Name": "Rajul",
-    "Last Name": "Vadera",
-    "Email Address": "rv4bk@virginia.edu"
+    "Last Name": "Vadera"
   },
   {
+    "Email Address": "shubhangisehrawat67@gmail.com",
     "First Name": "Shubhangi",
-    "Last Name": "Sehrawat",
-    "Email Address": "shubhangisehrawat67@gmail.com"
+    "Last Name": "Sehrawat"
   },
   {
+    "Email Address": "c.m.chavezspence@gmail.com",
     "First Name": "Christian",
-    "Last Name": "Chavez",
-    "Email Address": "c.m.chavezspence@gmail.com"
+    "Last Name": "Chavez"
   },
   {
+    "Email Address": "radu.schirliu1@ucalgary.ca",
     "First Name": "Radu",
-    "Last Name": "Schirliu",
-    "Email Address": "radu.schirliu1@ucalgary.ca"
+    "Last Name": "Schirliu"
   },
   {
+    "Email Address": "tuico@ualberta.ca",
     "First Name": "Hanna",
-    "Last Name": "Tuico",
-    "Email Address": "tuico@ualberta.ca"
+    "Last Name": "Tuico"
   },
   {
+    "Email Address": "qasim@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qasim@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mrizk@ualberta.ca",
     "First Name": "Mostafa",
-    "Last Name": "Rizk",
-    "Email Address": "mrizk@ualberta.ca"
+    "Last Name": "Rizk"
   },
   {
+    "Email Address": "yycao@uw.edu",
     "First Name": "Yolanda",
-    "Last Name": "Cao",
-    "Email Address": "yycao@uw.edu"
+    "Last Name": "Cao"
   },
   {
+    "Email Address": "skhehra@ualberta.ca",
     "First Name": "Sukhnoor",
-    "Last Name": "Khehra",
-    "Email Address": "skhehra@ualberta.ca"
+    "Last Name": "Khehra"
   },
   {
+    "Email Address": "boytang@ualberta.ca",
     "First Name": "Diane",
-    "Last Name": "Boytang",
-    "Email Address": "boytang@ualberta.ca"
+    "Last Name": "Boytang"
   },
   {
+    "Email Address": "shjllana59@gmail.com",
     "First Name": "Lana",
-    "Last Name": "Shin",
-    "Email Address": "shjllana59@gmail.com"
+    "Last Name": "Shin"
   },
   {
+    "Email Address": "kpendry@ualberta.ca",
     "First Name": "Kane",
-    "Last Name": "Pendry",
-    "Email Address": "kpendry@ualberta.ca"
+    "Last Name": "Pendry"
   },
   {
+    "Email Address": "naajia@ualberta.ca",
     "First Name": "Naajia",
-    "Last Name": "Ali",
-    "Email Address": "naajia@ualberta.ca"
+    "Last Name": "Ali"
   },
   {
+    "Email Address": "joelwarrington@gmail.com",
     "First Name": "Joel",
-    "Last Name": "Warrington",
-    "Email Address": "joelwarrington@gmail.com"
+    "Last Name": "Warrington"
   },
   {
+    "Email Address": "ashwinramesh2000@gmail.com",
     "First Name": "Ashwin",
-    "Last Name": "Ramesh",
-    "Email Address": "ashwinramesh2000@gmail.com"
+    "Last Name": "Ramesh"
   },
   {
+    "Email Address": "fzhu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "fzhu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hahmed7816@scrippscollege.edu",
     "First Name": "Hana",
-    "Last Name": "Ahmed",
-    "Email Address": "hahmed7816@scrippscollege.edu"
+    "Last Name": "Ahmed"
   },
   {
+    "Email Address": "bhide@ualberta.ca",
     "First Name": "Anant",
-    "Last Name": "Bhide",
-    "Email Address": "bhide@ualberta.ca"
+    "Last Name": "Bhide"
   },
   {
+    "Email Address": "luke3@ualberta.ca",
     "First Name": "Luke",
-    "Last Name": "Schultz",
-    "Email Address": "luke3@ualberta.ca"
+    "Last Name": "Schultz"
   },
   {
+    "Email Address": "celina.sheng@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "celina.sheng@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "faryal@ualberta.ca",
+    "First Name": "Faryal",
+    "Last Name": "Faisal"
+  },
+  {
+    "Email Address": "gorantla@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gorantla@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dhopfe@ualberta.ca",
     "First Name": "Danielle",
-    "Last Name": "Hopfe",
-    "Email Address": "dhopfe@ualberta.ca"
+    "Last Name": "Hopfe"
   },
   {
+    "Email Address": "dharmesh@ualberta.ca",
     "First Name": "Dharmesh",
-    "Last Name": "Moradiya",
-    "Email Address": "dharmesh@ualberta.ca"
+    "Last Name": "Moradiya"
   },
   {
+    "Email Address": "wenhan6@ualberta.ca",
     "First Name": "Liam",
-    "Last Name": "Chen",
-    "Email Address": "wenhan6@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "akaujla@ualberta.ca",
     "First Name": "Amrit",
-    "Last Name": "Aujla",
-    "Email Address": "akaujla@ualberta.ca"
+    "Last Name": "Aujla"
   },
   {
+    "Email Address": "sanya@ualberta.ca",
     "First Name": "Sanya",
-    "Last Name": "Arora",
-    "Email Address": "sanya@ualberta.ca"
+    "Last Name": "Arora"
   },
   {
+    "Email Address": "clair3yw@gmail.com",
     "First Name": "Claire",
-    "Last Name": "Wang",
-    "Email Address": "clair3yw@gmail.com"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "chenlin@ualberta.ca",
     "First Name": "Chenlin",
-    "Last Name": "Cao",
-    "Email Address": "chenlin@ualberta.ca"
+    "Last Name": "Cao"
   },
   {
+    "Email Address": "qianqiu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qianqiu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gflynn@usc.edu",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gflynn@usc.edu"
+    "Last Name": ""
   },
   {
+    "Email Address": "cturner4@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cturner4@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yuetong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yuetong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "numasawa@ualberta.ca",
     "First Name": "Moe",
-    "Last Name": "Numasawa",
-    "Email Address": "numasawa@ualberta.ca"
+    "Last Name": "Numasawa"
   },
   {
+    "Email Address": "bindigan@ualberta.ca",
     "First Name": "Rachana",
-    "Last Name": "bindiganavily",
-    "Email Address": "bindigan@ualberta.ca"
+    "Last Name": "bindiganavily"
   },
   {
+    "Email Address": "xinkai@ualberta.ca",
     "First Name": "Xinkai",
-    "Last Name": "Xu",
-    "Email Address": "xinkai@ualberta.ca"
+    "Last Name": "Xu"
   },
   {
+    "Email Address": "philbert@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "philbert@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yguo12@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yguo12@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "iwelu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "iwelu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "cwschoep@ualberta.ca",
     "First Name": "Caleb",
-    "Last Name": "Schoepp",
-    "Email Address": "cwschoep@ualberta.ca"
+    "Last Name": "Schoepp"
   },
   {
+    "Email Address": "saakshi@ualberta.ca",
     "First Name": "Saakshi",
-    "Last Name": "Joshi",
-    "Email Address": "saakshi@ualberta.ca"
+    "Last Name": "Joshi"
   },
   {
+    "Email Address": "chloecoleongco@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "chloecoleongco@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "rkorde@ualberta.ca",
     "First Name": "Rahul",
-    "Last Name": "Korde",
-    "Email Address": "rkorde@ualberta.ca"
+    "Last Name": "Korde"
   },
   {
+    "Email Address": "haw1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "haw1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gkb5164@psu.edu",
     "First Name": "Guneet",
-    "Last Name": "Baweja",
-    "Email Address": "gkb5164@psu.edu"
+    "Last Name": "Baweja"
   },
   {
+    "Email Address": "tsreddy@umich.edu",
     "First Name": "Tejaswini",
-    "Last Name": "Srinivas Reddy",
-    "Email Address": "tsreddy@umich.edu"
+    "Last Name": "Srinivas Reddy"
   },
   {
+    "Email Address": "kbdeng@ualberta.ca",
     "First Name": "Kelly",
-    "Last Name": "Deng",
-    "Email Address": "kbdeng@ualberta.ca"
+    "Last Name": "Deng"
   },
   {
+    "Email Address": "almuhtad@ualberta.ca",
     "First Name": "Dimas",
-    "Last Name": "Sudjito",
-    "Email Address": "almuhtad@ualberta.ca"
+    "Last Name": "Sudjito"
   },
   {
+    "Email Address": "chisombi@ualberta.ca",
     "First Name": "Chisombili",
-    "Last Name": "Amah",
-    "Email Address": "chisombi@ualberta.ca"
+    "Last Name": "Amah"
   },
   {
+    "Email Address": "mdvo@usf.edu",
     "First Name": "Minh",
-    "Last Name": "Vo",
-    "Email Address": "mdvo@usf.edu"
+    "Last Name": "Vo"
   },
   {
+    "Email Address": "bknguyen@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bknguyen@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "przystup@ualberta.ca",
     "First Name": "Michael",
-    "Last Name": "Przystupa",
-    "Email Address": "przystup@ualberta.ca"
+    "Last Name": "Przystupa"
   },
   {
+    "Email Address": "neagu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "neagu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mmosazgh@gmail.com",
     "First Name": "Mardokay",
-    "Last Name": "Mosazghi",
-    "Email Address": "mmosazgh@gmail.com"
+    "Last Name": "Mosazghi"
   },
   {
+    "Email Address": "jdsteven@ualberta.ca",
     "First Name": "Justin",
-    "Last Name": "Stevens",
-    "Email Address": "jdsteven@ualberta.ca"
+    "Last Name": "Stevens"
   },
   {
+    "Email Address": "yuhsiang@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yuhsiang@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "thanh2@ualberta.ca",
     "First Name": "Thanh",
-    "Last Name": "Nguyen",
-    "Email Address": "thanh2@ualberta.ca"
+    "Last Name": "Nguyen"
   },
   {
+    "Email Address": "tujuba@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tujuba@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "megali@ualberta.ca",
     "First Name": "Megali",
-    "Last Name": "Marsh",
-    "Email Address": "megali@ualberta.ca"
+    "Last Name": "Marsh"
   },
   {
+    "Email Address": "xishi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xishi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rupehra@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rupehra@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "cgratton@ualberta.ca",
     "First Name": "Chase",
-    "Last Name": "Gratton",
-    "Email Address": "cgratton@ualberta.ca"
+    "Last Name": "Gratton"
   },
   {
+    "Email Address": "ashamallapragada@gmail.com",
     "First Name": "Asha Jyoti",
-    "Last Name": "Mallapragada",
-    "Email Address": "ashamallapragada@gmail.com"
+    "Last Name": "Mallapragada"
   },
   {
+    "Email Address": "kivrikog@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kivrikog@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "justinjo@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "justinjo@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "oliviahuegel@usf.edu",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "oliviahuegel@usf.edu"
+    "Last Name": ""
   },
   {
+    "Email Address": "muwalaka@ualberta.ca",
     "First Name": "Monica",
-    "Last Name": "Uwalaka",
-    "Email Address": "muwalaka@ualberta.ca"
+    "Last Name": "Uwalaka"
   },
   {
+    "Email Address": "matthew.e.taylor@ualberta.ca",
     "First Name": "Matt",
-    "Last Name": "Taylor",
-    "Email Address": "matthew.e.taylor@ualberta.ca"
+    "Last Name": "Taylor"
   },
   {
+    "Email Address": "msellers@ualberta.ca",
     "First Name": "Marc",
-    "Last Name": "Sellers",
-    "Email Address": "msellers@ualberta.ca"
+    "Last Name": "Sellers"
   },
   {
+    "Email Address": "svu03@mylangara.ca",
     "First Name": "Shayla",
-    "Last Name": "Vu",
-    "Email Address": "svu03@mylangara.ca"
+    "Last Name": "Vu"
   },
   {
+    "Email Address": "qlan3@ualberta.ca",
     "First Name": "Qingfeng",
-    "Last Name": "Lan",
-    "Email Address": "qlan3@ualberta.ca"
+    "Last Name": "Lan"
   },
   {
+    "Email Address": "f20170638@pilani.bits-pilani.ac.in",
     "First Name": "Rishabh",
-    "Last Name": "Arora",
-    "Email Address": "f20170638@pilani.bits-pilani.ac.in"
+    "Last Name": "Arora"
   },
   {
+    "Email Address": "mcmorris@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mcmorris@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nehemi@ualberta.ca",
     "First Name": "Nehemi",
-    "Last Name": "Jutras",
-    "Email Address": "nehemi@ualberta.ca"
+    "Last Name": "Jutras"
   },
   {
+    "Email Address": "uali1@ualberta.ca",
     "First Name": "Usama",
-    "Last Name": "Ali",
-    "Email Address": "uali1@ualberta.ca"
+    "Last Name": "Ali"
   },
   {
+    "Email Address": "andrearamirezfernandez@gmail.com",
     "First Name": "Andrea",
-    "Last Name": "Ramirez",
-    "Email Address": "andrearamirezfernandez@gmail.com"
+    "Last Name": "Ramirez"
   },
   {
+    "Email Address": "hliu11@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hliu11@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ppascual@ualberta.ca",
     "First Name": "Gio",
-    "Last Name": "Pascual",
-    "Email Address": "ppascual@ualberta.ca"
+    "Last Name": "Pascual"
   },
   {
+    "Email Address": "jadhav@ualberta.ca",
     "First Name": "Avnish",
-    "Last Name": "Jadhav",
-    "Email Address": "jadhav@ualberta.ca"
+    "Last Name": "Jadhav"
   },
   {
+    "Email Address": "pater16@mcmaster.ca",
     "First Name": "Ritesh",
-    "Last Name": "Patel",
-    "Email Address": "pater16@mcmaster.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "cle4@ualberta.ca",
     "First Name": "Christopher",
-    "Last Name": "Le",
-    "Email Address": "cle4@ualberta.ca"
+    "Last Name": "Le"
   },
   {
+    "Email Address": "harsh4@ualberta.ca",
     "First Name": "Harsh",
-    "Last Name": "Patel",
-    "Email Address": "harsh4@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "sma2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sma2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "khushi3@ualberta.ca",
     "First Name": "Khushi",
-    "Last Name": "Shah",
-    "Email Address": "khushi3@ualberta.ca"
+    "Last Name": "Shah"
   },
   {
+    "Email Address": "sitongli1993@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sitongli1993@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "Veldhuis@ualberta.ca",
     "First Name": "Tyler",
-    "Last Name": "Veldhuis",
-    "Email Address": "Veldhuis@ualberta.ca"
+    "Last Name": "Veldhuis"
   },
   {
+    "Email Address": "mokhtar@ualberta.ca",
     "First Name": "mohamad",
-    "Last Name": "mokhtar",
-    "Email Address": "mokhtar@ualberta.ca"
+    "Last Name": "mokhtar"
   },
   {
+    "Email Address": "xuanzhu@ualberta.ca",
     "First Name": "Xuanzhu",
-    "Last Name": "Shang",
-    "Email Address": "xuanzhu@ualberta.ca"
+    "Last Name": "Shang"
   },
   {
+    "Email Address": "irisiris@live.unc.edu",
     "First Name": "Iris",
-    "Last Name": "Chien",
-    "Email Address": "irisiris@live.unc.edu"
+    "Last Name": "Chien"
   },
   {
+    "Email Address": "abudac@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "abudac@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "scheers@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "scheers@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hbagan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hbagan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jungeun4@ualberta.ca",
     "First Name": "Jamie",
-    "Last Name": "Lee",
-    "Email Address": "jungeun4@ualberta.ca"
+    "Last Name": "Lee"
   },
   {
+    "Email Address": "jorden1@ualberta.ca",
     "First Name": "Jorden",
-    "Last Name": "Hansen",
-    "Email Address": "jorden1@ualberta.ca"
+    "Last Name": "Hansen"
   },
   {
+    "Email Address": "kuchiman@ualberta.ca",
     "First Name": "Satyaswarupa",
-    "Last Name": "Kuchimanchi",
-    "Email Address": "kuchiman@ualberta.ca"
+    "Last Name": "Kuchimanchi"
   },
   {
+    "Email Address": "manpreet22.lko@gmail.com",
     "First Name": "Manpreet",
-    "Last Name": "Singh",
-    "Email Address": "manpreet22.lko@gmail.com"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "ale2@ualberta.ca",
     "First Name": "Andy",
-    "Last Name": "Le",
-    "Email Address": "ale2@ualberta.ca"
+    "Last Name": "Le"
   },
   {
+    "Email Address": "nandyalatharuni@gmail.com",
     "First Name": "Tharuni",
-    "Last Name": "Nandyala",
-    "Email Address": "nandyalatharuni@gmail.com"
+    "Last Name": "Nandyala"
   },
   {
+    "Email Address": "akash.saravanan@ualberta.ca",
     "First Name": "Akash",
-    "Last Name": "Saravanan",
-    "Email Address": "akash.saravanan@ualberta.ca"
+    "Last Name": "Saravanan"
   },
   {
+    "Email Address": "braedy@ualberta.ca",
     "First Name": "Braedy",
-    "Last Name": "Kuzma",
-    "Email Address": "braedy@ualberta.ca"
+    "Last Name": "Kuzma"
   },
   {
+    "Email Address": "Janelle.olu@icloud.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "Janelle.olu@icloud.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "ashley.chang@rutgers.edu",
     "First Name": "Ashley",
-    "Last Name": "Chang",
-    "Email Address": "ashley.chang@rutgers.edu"
+    "Last Name": "Chang"
   },
   {
+    "Email Address": "Yashar@ualberta.ca",
     "First Name": "Yashar",
-    "Last Name": "Kor",
-    "Email Address": "Yashar@ualberta.ca"
+    "Last Name": "Kor"
   },
   {
+    "Email Address": "sabadash@ualberta.ca",
     "First Name": "Carter",
-    "Last Name": "Sabadash",
-    "Email Address": "sabadash@ualberta.ca"
+    "Last Name": "Sabadash"
   },
   {
+    "Email Address": "gopal.arohi@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gopal.arohi@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "yingxi@ualberta.ca",
     "First Name": "yingxi",
-    "Last Name": "zhou",
-    "Email Address": "yingxi@ualberta.ca"
+    "Last Name": "zhou"
   },
   {
+    "Email Address": "maren1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "maren1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "pagadalaShilpakumari@hotmail.com",
     "First Name": "Shilpa",
-    "Last Name": "Pagadala",
-    "Email Address": "pagadalaShilpakumari@hotmail.com"
+    "Last Name": "Pagadala"
   },
   {
+    "Email Address": "haquino@ualberta.ca",
     "First Name": "Helen",
-    "Last Name": "Aquino",
-    "Email Address": "haquino@ualberta.ca"
+    "Last Name": "Aquino"
   },
   {
+    "Email Address": "musab.nassah@gmail.com",
     "First Name": "Musab",
-    "Last Name": "Hassan",
-    "Email Address": "musab.nassah@gmail.com"
+    "Last Name": "Hassan"
   },
   {
+    "Email Address": "sandy6@ualberta.ca",
     "First Name": "Sandy",
-    "Last Name": "Huang",
-    "Email Address": "sandy6@ualberta.ca"
+    "Last Name": "Huang"
   },
   {
+    "Email Address": "malco.macarthur@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "malco.macarthur@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "melih@ualberta.ca",
     "First Name": "Melih",
-    "Last Name": "Keskin",
-    "Email Address": "melih@ualberta.ca"
+    "Last Name": "Keskin"
   },
   {
+    "Email Address": "saumya.jain.470@gmail.com",
     "First Name": "Saumya",
-    "Last Name": "Jain",
-    "Email Address": "saumya.jain.470@gmail.com"
+    "Last Name": "Jain"
   },
   {
+    "Email Address": "ikjotk4@gmail.com",
     "First Name": "Ikjot",
-    "Last Name": "Kaur",
-    "Email Address": "ikjotk4@gmail.com"
+    "Last Name": "Kaur"
   },
   {
+    "Email Address": "kailash@ualberta.ca",
     "First Name": "Kailash",
-    "Last Name": "Seshadri",
-    "Email Address": "kailash@ualberta.ca"
+    "Last Name": "Seshadri"
   },
   {
+    "Email Address": "yutong3@ualberta.ca",
     "First Name": "Mimi",
-    "Last Name": "Zhang",
-    "Email Address": "yutong3@ualberta.ca"
+    "Last Name": "Zhang"
   },
   {
+    "Email Address": "elianalopezsilva@yahoo.com",
     "First Name": "Eliana",
-    "Last Name": "Lopez",
-    "Email Address": "elianalopezsilva@yahoo.com"
+    "Last Name": "Lopez"
   },
   {
+    "Email Address": "venhuis@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "venhuis@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hzamora@ualberta.ca",
     "First Name": "Hannah",
-    "Last Name": "Zamora",
-    "Email Address": "hzamora@ualberta.ca"
+    "Last Name": "Zamora"
   },
   {
+    "Email Address": "kespirit@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kespirit@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nandoh@ualberta.ca",
     "First Name": "Nana",
-    "Last Name": "Andoh",
-    "Email Address": "nandoh@ualberta.ca"
+    "Last Name": "Andoh"
   },
   {
+    "Email Address": "hpatel2@ualberta.ca",
     "First Name": "Harshini",
-    "Last Name": "Patel",
-    "Email Address": "hpatel2@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "sergii@ualberta.ca",
     "First Name": "Sergii",
-    "Last Name": "Penner",
-    "Email Address": "sergii@ualberta.ca"
+    "Last Name": "Penner"
   },
   {
+    "Email Address": "sh.shafeie@gmail.com",
     "First Name": "Shu",
-    "Last Name": "Shafe",
-    "Email Address": "sh.shafeie@gmail.com"
+    "Last Name": "Shafe"
   },
   {
+    "Email Address": "nataliekalin@alumni.mines.edu",
     "First Name": "Natalie",
-    "Last Name": "Kalin",
-    "Email Address": "nataliekalin@alumni.mines.edu"
+    "Last Name": "Kalin"
   },
   {
+    "Email Address": "anusha2304@gmail.com",
     "First Name": "Anusha",
-    "Last Name": "Hariharan",
-    "Email Address": "anusha2304@gmail.com"
+    "Last Name": "Hariharan"
   },
   {
+    "Email Address": "goodliff@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "goodliff@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "leah.hackman@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "leah.hackman@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "fn1@ualberta.ca",
     "First Name": "Faiza",
-    "Last Name": "Noor",
-    "Email Address": "fn1@ualberta.ca"
+    "Last Name": "Noor"
   },
   {
+    "Email Address": "qali@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qali@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jzzheng@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jzzheng@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "wenchen@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "wenchen@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sanaabhaidani1976@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sanaabhaidani1976@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "deanna@altaml.com",
     "First Name": "Deanna",
-    "Last Name": "Brousseau",
-    "Email Address": "deanna@altaml.com"
+    "Last Name": "Brousseau"
   },
   {
+    "Email Address": "rachna.ahirwar@ufl.edu",
     "First Name": "Rachna",
-    "Last Name": "Ahirwar",
-    "Email Address": "rachna.ahirwar@ufl.edu"
+    "Last Name": "Ahirwar"
   },
   {
+    "Email Address": "jyuen1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jyuen1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "coleton.kotch@gmail.com",
     "First Name": "Coleton",
-    "Last Name": "Kotch",
-    "Email Address": "coleton.kotch@gmail.com"
+    "Last Name": "Kotch"
   },
   {
+    "Email Address": "ztomkow@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ztomkow@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "pdpatel1@ualberta.ca",
     "First Name": "Pratham",
-    "Last Name": "Patel",
-    "Email Address": "pdpatel1@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "ssiyer@ualberta.ca",
     "First Name": "Suvan",
-    "Last Name": "Suresh",
-    "Email Address": "ssiyer@ualberta.ca"
+    "Last Name": "Suresh"
   },
   {
+    "Email Address": "halamurshed@yahoo.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "halamurshed@yahoo.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "dkam@ualberta.ca",
     "First Name": "Davina",
-    "Last Name": "Kam",
-    "Email Address": "dkam@ualberta.ca"
+    "Last Name": "Kam"
   },
   {
+    "Email Address": "arianneghislaine.rull@student.tdsb.on.ca",
     "First Name": "Arianne Ghislaine",
-    "Last Name": "Rull",
-    "Email Address": "arianneghislaine.rull@student.tdsb.on.ca"
+    "Last Name": "Rull"
   },
   {
+    "Email Address": "ksunisth@gmail.com",
     "First Name": "Sunisth",
-    "Last Name": "Kumar",
-    "Email Address": "ksunisth@gmail.com"
+    "Last Name": "Kumar"
   },
   {
+    "Email Address": "natalie.ekalin@gmail.com",
     "First Name": "Natalie",
-    "Last Name": "Kalin",
-    "Email Address": "natalie.ekalin@gmail.com"
+    "Last Name": "Kalin"
   },
   {
+    "Email Address": "vkambham@usc.edu",
     "First Name": "Vidya Meenakshi",
-    "Last Name": "Kambhampati",
-    "Email Address": "vkambham@usc.edu"
+    "Last Name": "Kambhampati"
   },
   {
+    "Email Address": "gurbir@ualberta.ca",
     "First Name": "Gurbir",
-    "Last Name": "Sandha",
-    "Email Address": "gurbir@ualberta.ca"
+    "Last Name": "Sandha"
   },
   {
+    "Email Address": "renyu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "renyu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ingabire@ualberta.ca",
     "First Name": "Daniella",
-    "Last Name": "Ingabire",
-    "Email Address": "ingabire@ualberta.ca"
+    "Last Name": "Ingabire"
   },
   {
+    "Email Address": "rdb3@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rdb3@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "syu3@ualberta.ca",
     "First Name": "Siyuan",
-    "Last Name": "Yu",
-    "Email Address": "syu3@ualberta.ca"
+    "Last Name": "Yu"
   },
   {
+    "Email Address": "ychen17@ualberta.ca",
     "First Name": "Yu",
-    "Last Name": "Chen",
-    "Email Address": "ychen17@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "syedsabe@ualberta.ca",
     "First Name": "Syed Sabeeh",
-    "Last Name": "Ali",
-    "Email Address": "syedsabe@ualberta.ca"
+    "Last Name": "Ali"
   },
   {
+    "Email Address": "csheng2@ualberta.ca",
     "First Name": "Celina",
-    "Last Name": "Sheng",
-    "Email Address": "csheng2@ualberta.ca"
+    "Last Name": "Sheng"
   },
   {
+    "Email Address": "teadams@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "teadams@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "exu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "exu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "raunakagarwal1302@gmail.com",
     "First Name": "Raunak",
-    "Last Name": "Agarwal",
-    "Email Address": "raunakagarwal1302@gmail.com"
+    "Last Name": "Agarwal"
   },
   {
+    "Email Address": "jinglong@ualberta.ca",
     "First Name": "Jinglong",
-    "Last Name": "Zhao",
-    "Email Address": "jinglong@ualberta.ca"
+    "Last Name": "Zhao"
   },
   {
+    "Email Address": "dpaudel@ualberta.ca",
     "First Name": "Deepak",
-    "Last Name": "Paudel",
-    "Email Address": "dpaudel@ualberta.ca"
+    "Last Name": "Paudel"
   },
   {
+    "Email Address": "hoeun@ualberta.ca",
     "First Name": "Bibianna",
-    "Last Name": "Lee",
-    "Email Address": "hoeun@ualberta.ca"
+    "Last Name": "Lee"
   },
   {
+    "Email Address": "pernudi@ualberta.ca",
     "First Name": "Giancarlo",
-    "Last Name": "Pernudi Segura",
-    "Email Address": "pernudi@ualberta.ca"
+    "Last Name": "Pernudi Segura"
   },
   {
+    "Email Address": "mahekk@sfu.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mahekk@sfu.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "janetchung@cs.uchicago.edu",
     "First Name": "Janet",
-    "Last Name": "Chung",
-    "Email Address": "janetchung@cs.uchicago.edu"
+    "Last Name": "Chung"
   },
   {
+    "Email Address": "woosaree@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "woosaree@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "amuresan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "amuresan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "czeto@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "czeto@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "maithrre@ualberta.ca",
     "First Name": "Maithrreye",
-    "Last Name": "Srinivasan",
-    "Email Address": "maithrre@ualberta.ca"
+    "Last Name": "Srinivasan"
   },
   {
+    "Email Address": "YFAN14ENHC@wfgmail.ca",
     "First Name": "Yechao",
-    "Last Name": "Fan",
-    "Email Address": "YFAN14ENHC@wfgmail.ca"
+    "Last Name": "Fan"
   },
   {
+    "Email Address": "shamsahsan90@gmail.com",
     "First Name": "Shams",
-    "Last Name": "Ahsanulllah",
-    "Email Address": "shamsahsan90@gmail.com"
+    "Last Name": "Ahsanulllah"
   },
   {
+    "Email Address": "vienna2@ualberta.ca",
     "First Name": "Vienna",
-    "Last Name": "Chen",
-    "Email Address": "vienna2@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "ravneetbrar9000@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ravneetbrar9000@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "burnt.rain@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "burnt.rain@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "sunjoth@ualberta.ca",
     "First Name": "Sunjoth",
-    "Last Name": "Bhangoo",
-    "Email Address": "sunjoth@ualberta.ca"
+    "Last Name": "Bhangoo"
   },
   {
+    "Email Address": "neha_kasturia@hotmail.com",
     "First Name": "Neha",
-    "Last Name": "Kasturia",
-    "Email Address": "neha_kasturia@hotmail.com"
+    "Last Name": "Kasturia"
   },
   {
+    "Email Address": "chuyang1@ualberta.ca",
     "First Name": "Chuyang",
-    "Last Name": "LIU",
-    "Email Address": "chuyang1@ualberta.ca"
+    "Last Name": "LIU"
   },
   {
+    "Email Address": "henryhe707@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "henryhe707@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "ikgadani@gmai.com",
     "First Name": "Isha",
-    "Last Name": "Gadani",
-    "Email Address": "ikgadani@gmai.com"
+    "Last Name": "Gadani"
   },
   {
+    "Email Address": "akrebs@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "akrebs@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nicholasguan20@gmail.com",
     "First Name": "Nick",
-    "Last Name": "Guan",
-    "Email Address": "nicholasguan20@gmail.com"
+    "Last Name": "Guan"
   },
   {
+    "Email Address": "qsong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qsong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dbehdwns0903@gmail.com",
     "First Name": "John",
-    "Last Name": "Yu",
-    "Email Address": "dbehdwns0903@gmail.com"
+    "Last Name": "Yu"
   },
   {
+    "Email Address": "kotha@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kotha@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "svidal@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "svidal@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "cancheta@ualberta.ca",
     "First Name": "Charles",
-    "Last Name": "Ancheta",
-    "Email Address": "cancheta@ualberta.ca"
+    "Last Name": "Ancheta"
   },
   {
+    "Email Address": "akpati@ualberta.ca",
     "First Name": "Theodore",
-    "Last Name": "Akpati",
-    "Email Address": "akpati@ualberta.ca"
+    "Last Name": "Akpati"
   },
   {
+    "Email Address": "xingjie1@ualberta.ca",
     "First Name": "Xingjie",
-    "Last Name": "He",
-    "Email Address": "xingjie1@ualberta.ca"
+    "Last Name": "He"
   },
   {
+    "Email Address": "falade@ualberta.ca",
     "First Name": "Irene",
-    "Last Name": "Falade",
-    "Email Address": "falade@ualberta.ca"
+    "Last Name": "Falade"
   },
   {
+    "Email Address": "zhibo4@ualberta.ca",
     "First Name": "Zhibo",
-    "Last Name": "Yuan",
-    "Email Address": "zhibo4@ualberta.ca"
+    "Last Name": "Yuan"
   },
   {
+    "Email Address": "sli2232@uwo.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sli2232@uwo.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kazihasi@ualberta.ca",
     "First Name": "Kazi Hasin",
-    "Last Name": "Sohail",
-    "Email Address": "kazihasi@ualberta.ca"
+    "Last Name": "Sohail"
   },
   {
+    "Email Address": "pouneh@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "pouneh@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "triparnabh@gmail.com",
     "First Name": "Triparna",
-    "Last Name": "Bhattacharya",
-    "Email Address": "triparnabh@gmail.com"
+    "Last Name": "Bhattacharya"
   },
   {
+    "Email Address": "moeid@ualberta.ca",
     "First Name": "Moeid",
-    "Last Name": "Khan",
-    "Email Address": "moeid@ualberta.ca"
+    "Last Name": "Khan"
   },
   {
+    "Email Address": "tarush@ualberta.ca",
     "First Name": "Tarush",
-    "Last Name": "Shankar",
-    "Email Address": "tarush@ualberta.ca"
+    "Last Name": "Shankar"
   },
   {
+    "Email Address": "jagirdar@ualberta.ca",
     "First Name": "Syed Sami Ahmed (Sami)",
-    "Last Name": "Jagirdar",
-    "Email Address": "jagirdar@ualberta.ca"
+    "Last Name": "Jagirdar"
   },
   {
+    "Email Address": "marialejandralfonso@gmail.com",
     "First Name": "MARIA ALEJANDRA",
-    "Last Name": "ALFONSO MUÑOZ",
-    "Email Address": "marialejandralfonso@gmail.com"
+    "Last Name": "ALFONSO MUÑOZ"
   },
   {
+    "Email Address": "prinsp2@mymacewan.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "prinsp2@mymacewan.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gozhora@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gozhora@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mh13@ualberta.ca",
     "First Name": "Muhammad Safwan",
-    "Last Name": "Hossain",
-    "Email Address": "mh13@ualberta.ca"
+    "Last Name": "Hossain"
   },
   {
+    "Email Address": "gachugu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gachugu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "patzelt@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "patzelt@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ssraza@ualberta.ca",
     "First Name": "Samir",
-    "Last Name": "Raza",
-    "Email Address": "ssraza@ualberta.ca"
+    "Last Name": "Raza"
   },
   {
+    "Email Address": "millea.timothy@gmail.com",
     "First Name": "Timothy",
-    "Last Name": "Millea",
-    "Email Address": "millea.timothy@gmail.com"
+    "Last Name": "Millea"
   },
   {
+    "Email Address": "ishire@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ishire@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kane.pendry@gmail.com",
     "First Name": "Kane",
-    "Last Name": "Pendry",
-    "Email Address": "kane.pendry@gmail.com"
+    "Last Name": "Pendry"
   },
   {
+    "Email Address": "upatel@ualberta.ca",
     "First Name": "Urvi",
-    "Last Name": "Patel",
-    "Email Address": "upatel@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "wnichols@ualberta.ca",
     "First Name": "William",
-    "Last Name": "Nichols",
-    "Email Address": "wnichols@ualberta.ca"
+    "Last Name": "Nichols"
   },
   {
+    "Email Address": "siemtewolde@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "siemtewolde@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "yfrempon@uncc.edu",
     "First Name": "Yaw",
-    "Last Name": "Frempong",
-    "Email Address": "yfrempon@uncc.edu"
+    "Last Name": "Frempong"
   },
   {
+    "Email Address": "julianne.md.mendoza@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "julianne.md.mendoza@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "yazdansh@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yazdansh@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gteklay251@mynorquest.ca",
     "First Name": "Gumesh",
-    "Last Name": "Teklay",
-    "Email Address": "gteklay251@mynorquest.ca"
+    "Last Name": "Teklay"
   },
   {
+    "Email Address": "esteki@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "esteki@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aborisso@ualberta.ca",
     "First Name": "Anastasia",
-    "Last Name": "Borissova",
-    "Email Address": "aborisso@ualberta.ca"
+    "Last Name": "Borissova"
   },
   {
+    "Email Address": "james.m.helberg@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "james.m.helberg@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "llx2@cornell.edu",
     "First Name": "Lucy",
-    "Last Name": "Xu",
-    "Email Address": "llx2@cornell.edu"
+    "Last Name": "Xu"
   },
   {
+    "Email Address": "mullick@ualberta.ca",
     "First Name": "Dhruv",
-    "Last Name": "Mullick",
-    "Email Address": "mullick@ualberta.ca"
+    "Last Name": "Mullick"
   },
   {
+    "Email Address": "acrerar@ualberta.ca",
     "First Name": "Alessandra",
-    "Last Name": "Crerar",
-    "Email Address": "acrerar@ualberta.ca"
+    "Last Name": "Crerar"
   },
   {
+    "Email Address": "ayeshafatima977@gmail.com",
     "First Name": "Ayesha",
-    "Last Name": "Fatima",
-    "Email Address": "ayeshafatima977@gmail.com"
+    "Last Name": "Fatima"
   },
   {
+    "Email Address": "malbach@ualberta.ca",
     "First Name": "Michele",
-    "Last Name": "Albach",
-    "Email Address": "malbach@ualberta.ca"
+    "Last Name": "Albach"
   },
   {
+    "Email Address": "cfong@ualberta.ca",
     "First Name": "Celine",
-    "Last Name": "Fong",
-    "Email Address": "cfong@ualberta.ca"
+    "Last Name": "Fong"
   },
   {
+    "Email Address": "hitarth@ualberta.ca",
     "First Name": "Hitarth",
-    "Last Name": "Kothari",
-    "Email Address": "hitarth@ualberta.ca"
+    "Last Name": "Kothari"
   },
   {
+    "Email Address": "mashiad@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mashiad@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ajiitesh@ualberta.ca",
     "First Name": "Ajiitesh",
-    "Last Name": "Gupta",
-    "Email Address": "ajiitesh@ualberta.ca"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "mmohamed5504@gmail.com",
+    "First Name": "Mustafa",
+    "Last Name": "Mohamed"
+  },
+  {
+    "Email Address": "kuchiaditi@gmail.com",
     "First Name": "Aditi",
-    "Last Name": "Kuchi",
-    "Email Address": "kuchiaditi@gmail.com"
+    "Last Name": "Kuchi"
   },
   {
+    "Email Address": "akinrinm@ualberta.ca",
     "First Name": "Toluwalase",
-    "Last Name": "Akinrinmade",
-    "Email Address": "akinrinm@ualberta.ca"
+    "Last Name": "Akinrinmade"
   },
   {
+    "Email Address": "otrebski@ualberta.ca",
     "First Name": "Julia",
-    "Last Name": "Otrebski",
-    "Email Address": "otrebski@ualberta.ca"
+    "Last Name": "Otrebski"
   },
   {
+    "Email Address": "mejaka@iu.edu",
     "First Name": "Meenal",
-    "Last Name": "Jakatdar",
-    "Email Address": "mejaka@iu.edu"
+    "Last Name": "Jakatdar"
   },
   {
+    "Email Address": "gandhi@ualberta.ca",
     "First Name": "Krish",
-    "Last Name": "Gandhi",
-    "Email Address": "gandhi@ualberta.ca"
+    "Last Name": "Gandhi"
   },
   {
+    "Email Address": "ksachdev@ualberta.ca",
     "First Name": "Tij",
-    "Last Name": "Sachdeva",
-    "Email Address": "ksachdev@ualberta.ca"
+    "Last Name": "Sachdeva"
   },
   {
+    "Email Address": "rkelly3@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rkelly3@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "Sanyaarora245@gmail.com",
     "First Name": "Sanya",
-    "Last Name": "Arora",
-    "Email Address": "Sanyaarora245@gmail.com"
+    "Last Name": "Arora"
   },
   {
+    "Email Address": "homynyk@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "homynyk@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "abferrei@ualberta.ca",
     "First Name": "Aaron",
-    "Last Name": "Ferreira",
-    "Email Address": "abferrei@ualberta.ca"
+    "Last Name": "Ferreira"
   },
   {
+    "Email Address": "marosi@ualberta.ca",
     "First Name": "Anna",
-    "Last Name": "Marosi",
-    "Email Address": "marosi@ualberta.ca"
+    "Last Name": "Marosi"
   },
   {
+    "Email Address": "mlu1@ualberta.ca",
     "First Name": "Mingwei",
-    "Last Name": "Lu",
-    "Email Address": "mlu1@ualberta.ca"
+    "Last Name": "Lu"
   },
   {
+    "Email Address": "minhphuong227@gmail.com",
     "First Name": "Phuong",
-    "Last Name": "Nguyen",
-    "Email Address": "minhphuong227@gmail.com"
+    "Last Name": "Nguyen"
   },
   {
+    "Email Address": "heyang1@ualberta.ca",
     "First Name": "Heyang",
-    "Last Name": "Xu",
-    "Email Address": "heyang1@ualberta.ca"
+    "Last Name": "Xu"
   },
   {
+    "Email Address": "xuanyi@ulberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xuanyi@ulberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "vardan1@ualberta.ca",
     "First Name": "Vardan",
-    "Last Name": "Saini",
-    "Email Address": "vardan1@ualberta.ca"
+    "Last Name": "Saini"
   },
   {
+    "Email Address": "alizaaamirx@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "alizaaamirx@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "dsr2149@columbia.edu",
     "First Name": "Diana",
-    "Last Name": "Ro",
-    "Email Address": "dsr2149@columbia.edu"
+    "Last Name": "Ro"
   },
   {
+    "Email Address": "cmcinroy@ualberta.ca",
     "First Name": "Caleb",
-    "Last Name": "McInroy",
-    "Email Address": "cmcinroy@ualberta.ca"
+    "Last Name": "McInroy"
   },
   {
+    "Email Address": "nadeer@ualberta.ca",
     "First Name": "Adnan",
-    "Last Name": "Nadeer",
-    "Email Address": "nadeer@ualberta.ca"
+    "Last Name": "Nadeer"
   },
   {
+    "Email Address": "xiaole2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xiaole2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "MAO_YIMEI@163.COM",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "MAO_YIMEI@163.COM"
+    "Last Name": ""
   },
   {
+    "Email Address": "union@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "union@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "stacey.sayler@ualberta.ca",
     "First Name": "Stacey",
-    "Last Name": "Sayler",
-    "Email Address": "stacey.sayler@ualberta.ca"
+    "Last Name": "Sayler"
   },
   {
+    "Email Address": "1000276794@ualberta.ca",
     "First Name": "Vedant",
-    "Last Name": "Vyas",
-    "Email Address": "1000276794@ualberta.ca"
+    "Last Name": "Vyas"
   },
   {
+    "Email Address": "mamyot@ualberta.ca",
     "First Name": "Link",
-    "Last Name": "Amyot",
-    "Email Address": "mamyot@ualberta.ca"
+    "Last Name": "Amyot"
   },
   {
+    "Email Address": "lavansh@ualberta.ca",
     "First Name": "Lavansh",
-    "Last Name": "Sethi",
-    "Email Address": "lavansh@ualberta.ca"
+    "Last Name": "Sethi"
   },
   {
+    "Email Address": "isc@teamupscience.com",
     "First Name": "Jing",
-    "Last Name": "Huang",
-    "Email Address": "isc@teamupscience.com"
+    "Last Name": "Huang"
   },
   {
+    "Email Address": "akshata.punganur@gmail.com",
     "First Name": "Akshata",
-    "Last Name": "Punganur",
-    "Email Address": "akshata.punganur@gmail.com"
+    "Last Name": "Punganur"
   },
   {
+    "Email Address": "dnagaraj@stanford.edu",
     "First Name": "Divya",
-    "Last Name": "Nagaraj",
-    "Email Address": "dnagaraj@stanford.edu"
+    "Last Name": "Nagaraj"
   },
   {
+    "Email Address": "sadhnani@ualberta.ca",
     "First Name": "Jugal",
-    "Last Name": "Sadhnani",
-    "Email Address": "sadhnani@ualberta.ca"
+    "Last Name": "Sadhnani"
   },
   {
+    "Email Address": "decheng1@ualberta.ca",
     "First Name": "Decheng",
-    "Last Name": "Wang",
-    "Email Address": "decheng1@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "mehak@vt.edu",
     "First Name": "Mehak",
-    "Last Name": "Kamal",
-    "Email Address": "mehak@vt.edu"
+    "Last Name": "Kamal"
   },
   {
+    "Email Address": "abdi.tujubans.86@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "abdi.tujubans.86@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "thoutams1@montclair.edu",
     "First Name": "Sai",
-    "Last Name": "Thoutam",
-    "Email Address": "thoutams1@montclair.edu"
+    "Last Name": "Thoutam"
   },
   {
+    "Email Address": "Wadika@ualbert.ca",
+    "First Name": "Wadika",
+    "Last Name": "Faisal"
+  },
+  {
+    "Email Address": "Samantha.v.axline@vanderbilt.edu",
     "First Name": "Samantha",
-    "Last Name": "Axline",
-    "Email Address": "Samantha.v.axline@vanderbilt.edu"
+    "Last Name": "Axline"
   },
   {
+    "Email Address": "ziang6@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ziang6@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aamnanoor2002@gmail.com",
     "First Name": "Aamna",
-    "Last Name": "Noor",
-    "Email Address": "aamnanoor2002@gmail.com"
+    "Last Name": "Noor"
   },
   {
+    "Email Address": "qliang2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "qliang2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "subhamoy@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "subhamoy@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ashlau045@gmail.com",
     "First Name": "Ashley",
-    "Last Name": "Lau",
-    "Email Address": "ashlau045@gmail.com"
+    "Last Name": "Lau"
   },
   {
+    "Email Address": "ngcarpen@ualberta.ca",
     "First Name": "Nicolas",
-    "Last Name": "Carpenter",
-    "Email Address": "ngcarpen@ualberta.ca"
+    "Last Name": "Carpenter"
   },
   {
+    "Email Address": "mrg1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mrg1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yoginiku@ualberta.ca",
     "First Name": "Yogini",
-    "Last Name": "Patel",
-    "Email Address": "yoginiku@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "paradis2@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "paradis2@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ccheng1@ualberta.ca",
     "First Name": "Chanel",
-    "Last Name": "",
-    "Email Address": "ccheng1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dabin1@ualberta.ca",
     "First Name": "Dabin",
-    "Last Name": "Park",
-    "Email Address": "dabin1@ualberta.ca"
+    "Last Name": "Park"
   },
   {
+    "Email Address": "adasteam@ualberta.ca",
     "First Name": "Ada's",
-    "Last Name": "Team",
-    "Email Address": "adasteam@ualberta.ca"
+    "Last Name": "Team"
   },
   {
+    "Email Address": "xli@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xli@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "1000297767@ualberta.ca",
     "First Name": "Aryaman",
-    "Last Name": "Raina",
-    "Email Address": "1000297767@ualberta.ca"
+    "Last Name": "Raina"
   },
   {
+    "Email Address": "burr.cameron@gmail.com",
     "First Name": "Cameron",
-    "Last Name": "Burr",
-    "Email Address": "burr.cameron@gmail.com"
+    "Last Name": "Burr"
   },
   {
+    "Email Address": "guptav4@mymacewan.ca",
     "First Name": "Vasu",
-    "Last Name": "Gupta",
-    "Email Address": "guptav4@mymacewan.ca"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "mxwang@ualberta.ca",
     "First Name": "Michelle",
-    "Last Name": "Wang",
-    "Email Address": "mxwang@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "eredman@ualberta.ca",
     "First Name": "Eden",
-    "Last Name": "Redman",
-    "Email Address": "eredman@ualberta.ca"
+    "Last Name": "Redman"
   },
   {
+    "Email Address": "charleneleong84@gmail.com",
     "First Name": "Charlene",
-    "Last Name": "Leong",
-    "Email Address": "charleneleong84@gmail.com"
+    "Last Name": "Leong"
   },
   {
+    "Email Address": "carolinec.edu@gmail.com",
     "First Name": "Caroline",
-    "Last Name": "Chen",
-    "Email Address": "carolinec.edu@gmail.com"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "akolkar@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "akolkar@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "alishbah@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "alishbah@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nn2@ualberta.ca",
     "First Name": "Nathan",
-    "Last Name": "Nguyen",
-    "Email Address": "nn2@ualberta.ca"
+    "Last Name": "Nguyen"
   },
   {
+    "Email Address": "rujuta.ghate@student.ottawa.edu",
     "First Name": "Rujuta",
-    "Last Name": "Ghate",
-    "Email Address": "rujuta.ghate@student.ottawa.edu"
+    "Last Name": "Ghate"
   },
   {
+    "Email Address": "chelseachen893@gmail.com",
     "First Name": "Chelsea",
-    "Last Name": "Chen",
-    "Email Address": "chelseachen893@gmail.com"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "saadmani@ualberta.ca",
     "First Name": "Saadman",
-    "Last Name": "Islam Khan",
-    "Email Address": "saadmani@ualberta.ca"
+    "Last Name": "Islam Khan"
   },
   {
+    "Email Address": "sivengorn@gmail.com",
     "First Name": "SivEng",
-    "Last Name": "Orn",
-    "Email Address": "sivengorn@gmail.com"
+    "Last Name": "Orn"
   },
   {
+    "Email Address": "shambhavi0707@gmail.com",
     "First Name": "Shambhavi",
-    "Last Name": "Kumar Ranjeet",
-    "Email Address": "shambhavi0707@gmail.com"
+    "Last Name": "Kumar Ranjeet"
   },
   {
+    "Email Address": "linnrose@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "linnrose@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hselvakumar3@gatech.edu",
     "First Name": "Hemaa",
-    "Last Name": "Selvakumar",
-    "Email Address": "hselvakumar3@gatech.edu"
+    "Last Name": "Selvakumar"
   },
   {
+    "Email Address": "kristina_stephan@intuit.com",
     "First Name": "Kristina",
-    "Last Name": "Stephan",
-    "Email Address": "kristina_stephan@intuit.com"
+    "Last Name": "Stephan"
   },
   {
+    "Email Address": "zoe.goldstein@icahn.mssm.edu",
     "First Name": "Zoe",
-    "Last Name": "Goldstein",
-    "Email Address": "zoe.goldstein@icahn.mssm.edu"
+    "Last Name": "Goldstein"
   },
   {
+    "Email Address": "javid@ualberta.ca",
     "First Name": "Shukriya",
-    "Last Name": "Javid",
-    "Email Address": "javid@ualberta.ca"
+    "Last Name": "Javid"
   },
   {
+    "Email Address": "arevalo@ualberta.ca",
     "First Name": "Gisele",
-    "Last Name": "Arevalo",
-    "Email Address": "arevalo@ualberta.ca"
+    "Last Name": "Arevalo"
   },
   {
+    "Email Address": "nimmathi@ualberta.ca",
     "First Name": "Umesh",
-    "Last Name": "Nimmathi",
-    "Email Address": "nimmathi@ualberta.ca"
+    "Last Name": "Nimmathi"
   },
   {
+    "Email Address": "hyl3@rice.edu",
     "First Name": "Hannah",
-    "Last Name": "Lei",
-    "Email Address": "hyl3@rice.edu"
+    "Last Name": "Lei"
   },
   {
+    "Email Address": "musliman@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "musliman@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dteodore@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "dteodore@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "varshine28@gmail.com",
     "First Name": "Varshine",
-    "Last Name": "S",
-    "Email Address": "varshine28@gmail.com"
+    "Last Name": "S"
   },
   {
+    "Email Address": "soorajarakkal@gmail.com",
     "First Name": "Arakkal",
-    "Last Name": "Sooraj",
-    "Email Address": "soorajarakkal@gmail.com"
+    "Last Name": "Sooraj"
   },
   {
+    "Email Address": "hongchao@ualberta.ca",
     "First Name": "Hongchao",
-    "Last Name": "Xu",
-    "Email Address": "hongchao@ualberta.ca"
+    "Last Name": "Xu"
   },
   {
+    "Email Address": "ghassanz@ualberta.ca",
     "First Name": "Golnoush",
-    "Last Name": "Hassanzadeh",
-    "Email Address": "ghassanz@ualberta.ca"
+    "Last Name": "Hassanzadeh"
   },
   {
+    "Email Address": "mmackinn@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mmackinn@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "kpescado@ualberta.ca",
     "First Name": "Kathleen Loise",
-    "Last Name": "Pescador",
-    "Email Address": "kpescado@ualberta.ca"
+    "Last Name": "Pescador"
   },
   {
+    "Email Address": "aaraien@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aaraien@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mphan1@ualberta.ca",
     "First Name": "Melissa",
-    "Last Name": "Phan",
-    "Email Address": "mphan1@ualberta.ca"
+    "Last Name": "Phan"
   },
   {
+    "Email Address": "Ajaye@uofa.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "Ajaye@uofa.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "riell@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "riell@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hebatull@ualberta.ca",
     "First Name": "Heba",
-    "Last Name": "Iftikhar",
-    "Email Address": "hebatull@ualberta.ca"
+    "Last Name": "Iftikhar"
   },
   {
+    "Email Address": "sqli@ualberta.ca",
     "First Name": "Cynthia",
-    "Last Name": "",
-    "Email Address": "sqli@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "nabi1@ualberta.ca",
     "First Name": "Afaq",
-    "Last Name": "Nabi",
-    "Email Address": "nabi1@ualberta.ca"
+    "Last Name": "Nabi"
   },
   {
+    "Email Address": "mjadhav@ualberta.ca",
     "First Name": "Maithili",
-    "Last Name": "Jadhav",
-    "Email Address": "mjadhav@ualberta.ca"
+    "Last Name": "Jadhav"
   },
   {
+    "Email Address": "cxlu@wharton.upenn.edu",
     "First Name": "Christina",
-    "Last Name": "Lu",
-    "Email Address": "cxlu@wharton.upenn.edu"
+    "Last Name": "Lu"
   },
   {
+    "Email Address": "ananyanandiraju03@gmail.com",
     "First Name": "Ananya",
-    "Last Name": "",
-    "Email Address": "ananyanandiraju03@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "sushmithavasan95@gmail.com",
     "First Name": "Sushmitha",
-    "Last Name": "Thirumalaivasan",
-    "Email Address": "sushmithavasan95@gmail.com"
+    "Last Name": "Thirumalaivasan"
   },
   {
+    "Email Address": "marcinko@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "marcinko@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "seba@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "seba@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mckelvie@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mckelvie@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gezahegn@ualberta.ca",
     "First Name": "Helen",
-    "Last Name": "Gezahegn",
-    "Email Address": "gezahegn@ualberta.ca"
+    "Last Name": "Gezahegn"
   },
   {
+    "Email Address": "hackman@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hackman@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sashreek@ualberta.ca",
     "First Name": "Sashreek",
-    "Last Name": "Magan",
-    "Email Address": "sashreek@ualberta.ca"
+    "Last Name": "Magan"
   },
   {
+    "Email Address": "djhanna@ualberta.ca",
     "First Name": "Dylan",
-    "Last Name": "Hanna",
-    "Email Address": "djhanna@ualberta.ca"
+    "Last Name": "Hanna"
   },
   {
+    "Email Address": "seoyoung@ualberta.ca",
     "First Name": "Riley",
-    "Last Name": "Bok",
-    "Email Address": "seoyoung@ualberta.ca"
+    "Last Name": "Bok"
   },
   {
+    "Email Address": "nkhetarp@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nkhetarp@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sumeeye@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sumeeye@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jaspreetks99@icloud.com",
     "First Name": "Jaspreet",
-    "Last Name": "Kaur",
-    "Email Address": "jaspreetks99@icloud.com"
+    "Last Name": "Kaur"
   },
   {
+    "Email Address": "dahernan@ualberta.ca",
     "First Name": "Daniel",
-    "Last Name": "Hernandez-Mendoza",
-    "Email Address": "dahernan@ualberta.ca"
+    "Last Name": "Hernandez-Mendoza"
   },
   {
+    "Email Address": "dantasjulia03@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "dantasjulia03@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "gihozo@ualberta.ca",
     "First Name": "Arnold",
-    "Last Name": "Gihozo",
-    "Email Address": "gihozo@ualberta.ca"
+    "Last Name": "Gihozo"
   },
   {
+    "Email Address": "miyasc4277@gmail.com",
     "First Name": "sowmya",
-    "Last Name": "challa",
-    "Email Address": "miyasc4277@gmail.com"
+    "Last Name": "challa"
   },
   {
+    "Email Address": "syedtasd@ualberta.ca",
     "First Name": "Syed Tasdid Azam",
-    "Last Name": "Dhrubo",
-    "Email Address": "syedtasd@ualberta.ca"
+    "Last Name": "Dhrubo"
   },
   {
+    "Email Address": "ababzade@ualberta.ca",
     "First Name": "Reyhaneh",
-    "Last Name": "Ababzadeh",
-    "Email Address": "ababzade@ualberta.ca"
+    "Last Name": "Ababzadeh"
   },
   {
+    "Email Address": "nmady@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nmady@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "lrsouthwell@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "lrsouthwell@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "kylephil@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kylephil@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mrmaki@ualberta.ca",
     "First Name": "Mathew",
-    "Last Name": "Maki",
-    "Email Address": "mrmaki@ualberta.ca"
+    "Last Name": "Maki"
   },
   {
+    "Email Address": "phiangda@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "phiangda@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "shuo15@ualberta.ca",
     "First Name": "Shuo",
-    "Last Name": "Liu",
-    "Email Address": "shuo15@ualberta.ca"
+    "Last Name": "Liu"
   },
   {
+    "Email Address": "ferdousa@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ferdousa@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "cyan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cyan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "xuemeng2@ualberta.ca",
     "First Name": "Xuemeng",
-    "Last Name": "Wei",
-    "Email Address": "xuemeng2@ualberta.ca"
+    "Last Name": "Wei"
   },
   {
+    "Email Address": "ydong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ydong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "sereen.kallerackal@gmail.com",
     "First Name": "Sereen",
-    "Last Name": "Kallerackal",
-    "Email Address": "sereen.kallerackal@gmail.com"
+    "Last Name": "Kallerackal"
   },
   {
+    "Email Address": "ctkan@ualberta.ca",
     "First Name": "Curtis",
-    "Last Name": "Kan",
-    "Email Address": "ctkan@ualberta.ca"
+    "Last Name": "Kan"
   },
   {
+    "Email Address": "krezaeia@sfu.ca",
     "First Name": "Kimia",
-    "Last Name": "Rezaeian",
-    "Email Address": "krezaeia@sfu.ca"
+    "Last Name": "Rezaeian"
   },
   {
+    "Email Address": "jaber.babaki94@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jaber.babaki94@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "jiaye1@ualberta.ca",
     "First Name": "Jiaye",
-    "Last Name": "He",
-    "Email Address": "jiaye1@ualberta.ca"
+    "Last Name": "He"
   },
   {
+    "Email Address": "chiachen@ualberta.ca",
     "First Name": "Katie",
-    "Last Name": "Lin",
-    "Email Address": "chiachen@ualberta.ca"
+    "Last Name": "Lin"
   },
   {
+    "Email Address": "awood@ualberta.ca",
     "First Name": "Andrew",
-    "Last Name": "Wood",
-    "Email Address": "awood@ualberta.ca"
+    "Last Name": "Wood"
   },
   {
+    "Email Address": "jaya9300@mylaurier.ca",
     "First Name": "Thenura",
-    "Last Name": "Jayasinghe",
-    "Email Address": "jaya9300@mylaurier.ca"
+    "Last Name": "Jayasinghe"
   },
   {
+    "Email Address": "hongwei2@ualberta.ca",
     "First Name": "Hongwei",
-    "Last Name": "Wang",
-    "Email Address": "hongwei2@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "evanderm@ualberta.ca",
     "First Name": "Emily",
-    "Last Name": "Vandermeer",
-    "Email Address": "evanderm@ualberta.ca"
+    "Last Name": "Vandermeer"
   },
   {
+    "Email Address": "lethiraj@buffalo.edu",
     "First Name": "Lakshmi Prasanna",
-    "Last Name": "Ethiraj",
-    "Email Address": "lethiraj@buffalo.edu"
+    "Last Name": "Ethiraj"
   },
   {
+    "Email Address": "rxzhao@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "rxzhao@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "myounis@ualberta.ca",
     "First Name": "Mohamed",
-    "Last Name": "Younis",
-    "Email Address": "myounis@ualberta.ca"
+    "Last Name": "Younis"
   },
   {
+    "Email Address": "ashieze@ualberta.ca",
     "First Name": "David",
-    "Last Name": "Ashieze",
-    "Email Address": "ashieze@ualberta.ca"
+    "Last Name": "Ashieze"
   },
   {
+    "Email Address": "smeem@ualberta.ca",
     "First Name": "Shahreen",
-    "Last Name": "Meem",
-    "Email Address": "smeem@ualberta.ca"
+    "Last Name": "Meem"
   },
   {
+    "Email Address": "jared_scott@email.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jared_scott@email.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "kescia@ualberta.ca",
     "First Name": "Kescia",
-    "Last Name": "Doyle",
-    "Email Address": "kescia@ualberta.ca"
+    "Last Name": "Doyle"
   },
   {
+    "Email Address": "tajreen@ualberta.ca",
     "First Name": "Taj",
-    "Last Name": "Salim",
-    "Email Address": "tajreen@ualberta.ca"
+    "Last Name": "Salim"
   },
   {
+    "Email Address": "mdtouhid@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mdtouhid@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "fetterly@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "fetterly@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dhyey.lalseta@ucalgary.ca",
     "First Name": "Dhyey",
-    "Last Name": "Lalseta",
-    "Email Address": "dhyey.lalseta@ucalgary.ca"
+    "Last Name": "Lalseta"
   },
   {
+    "Email Address": "sgour@ualberta.ca",
     "First Name": "Sheetal",
-    "Last Name": "Gour",
-    "Email Address": "sgour@ualberta.ca"
+    "Last Name": "Gour"
   },
   {
+    "Email Address": "krause.lucrecia@gmail.com",
     "First Name": "Lucrecia",
-    "Last Name": "Krause",
-    "Email Address": "krause.lucrecia@gmail.com"
+    "Last Name": "Krause"
   },
   {
+    "Email Address": "jwisniew@ualberta.ca",
     "First Name": "Joshua",
-    "Last Name": "Wisniewski",
-    "Email Address": "jwisniew@ualberta.ca"
+    "Last Name": "Wisniewski"
   },
   {
+    "Email Address": "leawyoun@ualberta.ca",
     "First Name": "Emily",
-    "Last Name": "Leaw Youn",
-    "Email Address": "leawyoun@ualberta.ca"
+    "Last Name": "Leaw Youn"
   },
   {
+    "Email Address": "rsaqe@uwaterloo.ca",
     "First Name": "Rikard",
-    "Last Name": "Saqe",
-    "Email Address": "rsaqe@uwaterloo.ca"
+    "Last Name": "Saqe"
   },
   {
+    "Email Address": "lsood1@jhu.edu",
     "First Name": "Lakshay",
-    "Last Name": "Sood",
-    "Email Address": "lsood1@jhu.edu"
+    "Last Name": "Sood"
   },
   {
+    "Email Address": "saqlainsajid.ss@gmail.com",
     "First Name": "Saqlain",
-    "Last Name": "Sajid",
-    "Email Address": "saqlainsajid.ss@gmail.com"
+    "Last Name": "Sajid"
   },
   {
+    "Email Address": "saadmateen112@gmail.com",
     "First Name": "Saad",
-    "Last Name": "Mateen",
-    "Email Address": "saadmateen112@gmail.com"
+    "Last Name": "Mateen"
   },
   {
+    "Email Address": "avneet4@ualberta.ca",
     "First Name": "Avneet",
-    "Last Name": "Randhawa",
-    "Email Address": "avneet4@ualberta.ca"
+    "Last Name": "Randhawa"
   },
   {
+    "Email Address": "yismail@ualberta.ca",
     "First Name": "Youssef",
-    "Last Name": "Ismail",
-    "Email Address": "yismail@ualberta.ca"
+    "Last Name": "Ismail"
   },
   {
+    "Email Address": "naldrich@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "naldrich@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "chowk@oregonstate.edu",
     "First Name": "Katrine",
-    "Last Name": "Chow",
-    "Email Address": "chowk@oregonstate.edu"
+    "Last Name": "Chow"
   },
   {
+    "Email Address": "ysic@teamupscience.com",
     "First Name": "Jessica",
-    "Last Name": "Bennett",
-    "Email Address": "ysic@teamupscience.com"
+    "Last Name": "Bennett"
   },
   {
+    "Email Address": "briones@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "briones@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "vasiyakrishnan@gmail.com",
     "First Name": "Vasiya",
-    "Last Name": "Krishnan",
-    "Email Address": "vasiyakrishnan@gmail.com"
+    "Last Name": "Krishnan"
   },
   {
+    "Email Address": "shehroze@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "shehroze@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "snath@ualberta.ca",
     "First Name": "Sandipan",
-    "Last Name": "Nath",
-    "Email Address": "snath@ualberta.ca"
+    "Last Name": "Nath"
   },
   {
+    "Email Address": "jasonb.allen42@gmail.com",
     "First Name": "Jason",
-    "Last Name": "Branch-Allen",
-    "Email Address": "jasonb.allen42@gmail.com"
+    "Last Name": "Branch-Allen"
   },
   {
+    "Email Address": "laibah@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "laibah@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mekha.e.george@gmail.com",
     "First Name": "Mekha",
-    "Last Name": "",
-    "Email Address": "mekha.e.george@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "ngkwongs@ualberta.ca",
     "First Name": "Gary",
-    "Last Name": "Ng Kwong Sang",
-    "Email Address": "ngkwongs@ualberta.ca"
+    "Last Name": "Ng Kwong Sang"
   },
   {
+    "Email Address": "ritwik@ualberta.ca",
     "First Name": "Ritwik",
-    "Last Name": "Rastogi",
-    "Email Address": "ritwik@ualberta.ca"
+    "Last Name": "Rastogi"
   },
   {
+    "Email Address": "mim@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mim@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "amahesh@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "amahesh@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "lojpur@ualberta.ca",
     "First Name": "Samuel",
-    "Last Name": "Lojpur",
-    "Email Address": "lojpur@ualberta.ca"
+    "Last Name": "Lojpur"
   },
   {
+    "Email Address": "mayurpatel78645@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mayurpatel78645@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "mochenserey@gmail.com",
     "First Name": "Mo",
-    "Last Name": "Chen-Serey",
-    "Email Address": "mochenserey@gmail.com"
+    "Last Name": "Chen-Serey"
   },
   {
+    "Email Address": "cpeters@ualberta.ca",
     "First Name": "Cassidy",
-    "Last Name": "Peters",
-    "Email Address": "cpeters@ualberta.ca"
+    "Last Name": "Peters"
   },
   {
+    "Email Address": "hashemza@ualberta.ca",
     "First Name": "Maryam",
-    "Last Name": "Hashemzadeh",
-    "Email Address": "hashemza@ualberta.ca"
+    "Last Name": "Hashemzadeh"
   },
   {
+    "Email Address": "suyeon1@ualberta.ca",
     "First Name": "Suyeon",
-    "Last Name": "Lee",
-    "Email Address": "suyeon1@ualberta.ca"
+    "Last Name": "Lee"
   },
   {
+    "Email Address": "shinjni@email.arizona.edu",
     "First Name": "Shinjni",
-    "Last Name": "Maheshwari",
-    "Email Address": "shinjni@email.arizona.edu"
+    "Last Name": "Maheshwari"
   },
   {
+    "Email Address": "radi@ualberta.ca",
     "First Name": "Hager",
-    "Last Name": "Radi",
-    "Email Address": "radi@ualberta.ca"
+    "Last Name": "Radi"
   },
   {
+    "Email Address": "sngo.134@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sngo.134@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "sbibi@ualberta.ca",
     "First Name": "Sana",
-    "Last Name": "Bibi",
-    "Email Address": "sbibi@ualberta.ca"
+    "Last Name": "Bibi"
   },
   {
+    "Email Address": "haochen.lu@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "haochen.lu@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "manuba@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "manuba@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aktas@ualberta.ca",
     "First Name": "Fatih",
-    "Last Name": "Aktas",
-    "Email Address": "aktas@ualberta.ca"
+    "Last Name": "Aktas"
   },
   {
+    "Email Address": "nhossain@ualberta.ca",
     "First Name": "Nasif",
-    "Last Name": "Hossain",
-    "Email Address": "nhossain@ualberta.ca"
+    "Last Name": "Hossain"
   },
   {
+    "Email Address": "chatterl@ualberta.ca",
     "First Name": "Kyle",
-    "Last Name": "Chatterley",
-    "Email Address": "chatterl@ualberta.ca"
+    "Last Name": "Chatterley"
   },
   {
+    "Email Address": "mu6@ualberta.ca",
     "First Name": "Muhammad",
-    "Last Name": "Abdullah",
-    "Email Address": "mu6@ualberta.ca"
+    "Last Name": "Abdullah"
   },
   {
+    "Email Address": "astha.mehta.9@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "astha.mehta.9@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "mcfarlmi@oregonstate.edu",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mcfarlmi@oregonstate.edu"
+    "Last Name": ""
   },
   {
+    "Email Address": "Arora.aarushi95@gmail.com",
     "First Name": "Aarushi",
-    "Last Name": "B",
-    "Email Address": "Arora.aarushi95@gmail.com"
+    "Last Name": "B"
   },
   {
+    "Email Address": "sg474@duke.edu",
     "First Name": "Sauren",
-    "Last Name": "Gupta",
-    "Email Address": "sg474@duke.edu"
+    "Last Name": "Gupta"
   },
   {
+    "Email Address": "si2@ualberta.ca",
     "First Name": "Saqib",
-    "Last Name": "Ibrahim",
-    "Email Address": "si2@ualberta.ca"
+    "Last Name": "Ibrahim"
   },
   {
+    "Email Address": "aleialoi@ualberta.ca",
     "First Name": "Aleia",
-    "Last Name": "Cabote",
-    "Email Address": "aleialoi@ualberta.ca"
+    "Last Name": "Cabote"
   },
   {
+    "Email Address": "kalwani@ualberta.ca",
     "First Name": "Aryan",
-    "Last Name": "Kalwani",
-    "Email Address": "kalwani@ualberta.ca"
+    "Last Name": "Kalwani"
   },
   {
+    "Email Address": "raezan@ualberta.ca",
     "First Name": "Raezan",
-    "Last Name": "Villamor",
-    "Email Address": "raezan@ualberta.ca"
+    "Last Name": "Villamor"
   },
   {
+    "Email Address": "ysrivast@ualberta.ca",
     "First Name": "Yash",
-    "Last Name": "Srivastava",
-    "Email Address": "ysrivast@ualberta.ca"
+    "Last Name": "Srivastava"
   },
   {
+    "Email Address": "fabdolla@ualberta.ca",
     "First Name": "Fatemeh",
-    "Last Name": "Abdollahi",
-    "Email Address": "fabdolla@ualberta.ca"
+    "Last Name": "Abdollahi"
   },
   {
+    "Email Address": "yuanye@ualberta.ca",
     "First Name": "Yuanye",
-    "Last Name": "Lin",
-    "Email Address": "yuanye@ualberta.ca"
+    "Last Name": "Lin"
   },
   {
+    "Email Address": "juiwen@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "juiwen@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aditicho@usc.edu",
     "First Name": "Aditi",
-    "Last Name": "Choudhary",
-    "Email Address": "aditicho@usc.edu"
+    "Last Name": "Choudhary"
   },
   {
+    "Email Address": "yangyi1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yangyi1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yueling@ualberta.ca",
     "First Name": "Yueling",
-    "Last Name": "Chen",
-    "Email Address": "yueling@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "jlovrod@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jlovrod@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dorsa@ualberta.ca",
     "First Name": "Dorsa",
-    "Last Name": "Nahid",
-    "Email Address": "dorsa@ualberta.ca"
+    "Last Name": "Nahid"
   },
   {
+    "Email Address": "stroulia@ualberta.ca",
     "First Name": "Eleni",
-    "Last Name": "Stroulia",
-    "Email Address": "stroulia@ualberta.ca"
+    "Last Name": "Stroulia"
   },
   {
+    "Email Address": "somoza@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "somoza@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tuleen.awad@sfu.ca",
     "First Name": "Tuleen",
-    "Last Name": "Awad",
-    "Email Address": "tuleen.awad@sfu.ca"
+    "Last Name": "Awad"
   },
   {
+    "Email Address": "jkirker@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jkirker@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yuqian5@ualberta.ca",
     "First Name": "Kerry",
-    "Last Name": "Cao",
-    "Email Address": "yuqian5@ualberta.ca"
+    "Last Name": "Cao"
   },
   {
+    "Email Address": "czallan@ualberta.ca",
     "First Name": "Chase",
-    "Last Name": "Allan",
-    "Email Address": "czallan@ualberta.ca"
+    "Last Name": "Allan"
   },
   {
+    "Email Address": "swatic3@illinois.edu",
     "First Name": "Swati",
-    "Last Name": "Chauhan",
-    "Email Address": "swatic3@illinois.edu"
+    "Last Name": "Chauhan"
   },
   {
+    "Email Address": "soltanin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "soltanin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "budac@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "budac@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "twang11@ualberta.ca",
     "First Name": "Tianyi",
-    "Last Name": "Wang",
-    "Email Address": "twang11@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "bding@ualberta.ca",
     "First Name": "Beth",
-    "Last Name": "Ding",
-    "Email Address": "bding@ualberta.ca"
+    "Last Name": "Ding"
   },
   {
+    "Email Address": "cma2@ualberta.ca",
     "First Name": "chen",
-    "Last Name": "ma",
-    "Email Address": "cma2@ualberta.ca"
+    "Last Name": "ma"
   },
   {
+    "Email Address": "dxlu@ualberta.ca",
     "First Name": "Danny",
-    "Last Name": "Lu",
-    "Email Address": "dxlu@ualberta.ca"
+    "Last Name": "Lu"
   },
   {
+    "Email Address": "dwlau@ualberta.ca",
     "First Name": "Daisy",
-    "Last Name": "Lau",
-    "Email Address": "dwlau@ualberta.ca"
+    "Last Name": "Lau"
   },
   {
+    "Email Address": "kirezi@ualberta.ca",
     "First Name": "Laura",
-    "Last Name": "Kirezi",
-    "Email Address": "kirezi@ualberta.ca"
+    "Last Name": "Kirezi"
   },
   {
+    "Email Address": "mdu4@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "mdu4@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "dgoel1@ualberta.ca",
     "First Name": "Dave",
-    "Last Name": "Goel",
-    "Email Address": "dgoel1@ualberta.ca"
+    "Last Name": "Goel"
   },
   {
+    "Email Address": "yue5@ualberta.ca",
     "First Name": "Yifan",
-    "Last Name": "Yue",
-    "Email Address": "yue5@ualberta.ca"
+    "Last Name": "Yue"
   },
   {
+    "Email Address": "woongcha@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "woongcha@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "hsmalhi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hsmalhi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "makhache@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "makhache@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "gbullock@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gbullock@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rk6@ualberta.ca",
     "First Name": "Ravinder",
-    "Last Name": "kaur",
-    "Email Address": "rk6@ualberta.ca"
+    "Last Name": "kaur"
   },
   {
+    "Email Address": "ssajid@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ssajid@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tyc360@nyu.edu",
     "First Name": "Jessie",
-    "Last Name": "Chen",
-    "Email Address": "tyc360@nyu.edu"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "ria.ahir1@gmail.com",
     "First Name": "Ria",
-    "Last Name": "Ahir",
-    "Email Address": "ria.ahir1@gmail.com"
+    "Last Name": "Ahir"
   },
   {
+    "Email Address": "tahilianigeeta1203@gmail.com",
     "First Name": "Geeta",
-    "Last Name": "Tahiliani",
-    "Email Address": "tahilianigeeta1203@gmail.com"
+    "Last Name": "Tahiliani"
   },
   {
+    "Email Address": "manasi_khanuja@berkeley.edu",
     "First Name": "Manasi",
-    "Last Name": "Khanuja",
-    "Email Address": "manasi_khanuja@berkeley.edu"
+    "Last Name": "Khanuja"
   },
   {
+    "Email Address": "mjain02@syr.edu",
     "First Name": "Manasvi",
-    "Last Name": "Jain",
-    "Email Address": "mjain02@syr.edu"
+    "Last Name": "Jain"
   },
   {
+    "Email Address": "ymhwang1123@g.ucla.edu",
     "First Name": "Youyeon",
-    "Last Name": "Hwang",
-    "Email Address": "ymhwang1123@g.ucla.edu"
+    "Last Name": "Hwang"
   },
   {
+    "Email Address": "thanneer@ualberta.ca",
     "First Name": "Sree Nidhi",
-    "Last Name": "Thanneeru",
-    "Email Address": "thanneer@ualberta.ca"
+    "Last Name": "Thanneeru"
   },
   {
+    "Email Address": "pranj@ualberta.ca",
     "First Name": "Pranj",
-    "Last Name": "Patel",
-    "Email Address": "pranj@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "hye3@ualberta.ca",
     "First Name": "Felix",
-    "Last Name": "Ye",
-    "Email Address": "hye3@ualberta.ca"
+    "Last Name": "Ye"
   },
   {
+    "Email Address": "menghan4@ualberta.ca",
     "First Name": "Meghan",
-    "Last Name": "Chen",
-    "Email Address": "menghan4@ualberta.ca"
+    "Last Name": "Chen"
   },
   {
+    "Email Address": "indujat999@gmail.com",
     "First Name": "Induja",
-    "Last Name": "Thakkelapati",
-    "Email Address": "indujat999@gmail.com"
+    "Last Name": "Thakkelapati"
   },
   {
+    "Email Address": "abiha@ualberta.ca",
     "First Name": "Abbie",
-    "Last Name": "Raza",
-    "Email Address": "abiha@ualberta.ca"
+    "Last Name": "Raza"
   },
   {
+    "Email Address": "dolor@ualberta.ca",
     "First Name": "Aivan",
-    "Last Name": "Dolor",
-    "Email Address": "dolor@ualberta.ca"
+    "Last Name": "Dolor"
   },
   {
+    "Email Address": "carlknickle@gmail.com",
     "First Name": "Carl",
-    "Last Name": "Knickle",
-    "Email Address": "carlknickle@gmail.com"
+    "Last Name": "Knickle"
   },
   {
+    "Email Address": "aditi92agrawal@gmail.com",
     "First Name": "Aditi",
-    "Last Name": "Agrawal",
-    "Email Address": "aditi92agrawal@gmail.com"
+    "Last Name": "Agrawal"
   },
   {
+    "Email Address": "mdoshi@ualberta.ca",
     "First Name": "Mahin",
-    "Last Name": "Doshi",
-    "Email Address": "mdoshi@ualberta.ca"
+    "Last Name": "Doshi"
   },
   {
+    "Email Address": "rmandav@iu.edu",
     "First Name": "Ratna",
-    "Last Name": "Mandava",
-    "Email Address": "rmandav@iu.edu"
+    "Last Name": "Mandava"
   },
   {
+    "Email Address": "ataupill@ualberta.ca",
     "First Name": "Lidia",
-    "Last Name": "Ataupillco",
-    "Email Address": "ataupill@ualberta.ca"
+    "Last Name": "Ataupillco"
   },
   {
+    "Email Address": "jbendico@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jbendico@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ahou@ualberta.ca",
     "First Name": "Amy",
-    "Last Name": "Hou",
-    "Email Address": "ahou@ualberta.ca"
+    "Last Name": "Hou"
   },
   {
+    "Email Address": "krisschoneberg@improbable.io",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "krisschoneberg@improbable.io"
+    "Last Name": ""
   },
   {
+    "Email Address": "manraj3@ualberta.ca",
     "First Name": "Manraj",
-    "Last Name": "Singh",
-    "Email Address": "manraj3@ualberta.ca"
+    "Last Name": "Singh"
   },
   {
+    "Email Address": "alau4@ualberta.ca",
     "First Name": "Ashley",
-    "Last Name": "Lau",
-    "Email Address": "alau4@ualberta.ca"
+    "Last Name": "Lau"
   },
   {
+    "Email Address": "jhoover@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jhoover@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jiachen2@ualberta.ca",
     "First Name": "Jiachen",
-    "Last Name": "Xu",
-    "Email Address": "jiachen2@ualberta.ca"
+    "Last Name": "Xu"
   },
   {
+    "Email Address": "alex.wong@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "alex.wong@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "keanweng@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "keanweng@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "3mrfouad@gmail.com",
     "First Name": "Amr",
-    "Last Name": "Fouad",
-    "Email Address": "3mrfouad@gmail.com"
+    "Last Name": "Fouad"
   },
   {
+    "Email Address": "hobbes@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "hobbes@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mdamirul@ualberta.ca",
     "First Name": "Amirul",
-    "Last Name": "",
-    "Email Address": "mdamirul@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aemen1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aemen1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "tan4@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "tan4@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rmaghera@ualberta.ca",
     "First Name": "Rajan",
-    "Last Name": "Maghera",
-    "Email Address": "rmaghera@ualberta.ca"
+    "Last Name": "Maghera"
   },
   {
+    "Email Address": "kmbaker@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kmbaker@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ikeadeoyin@gmail.com",
     "First Name": "Oyindamola",
-    "Last Name": "Olatunji",
-    "Email Address": "ikeadeoyin@gmail.com"
+    "Last Name": "Olatunji"
   },
   {
+    "Email Address": "skazemia@ualberta.ca",
     "First Name": "Sepehr",
-    "Last Name": "Kazemian",
-    "Email Address": "skazemia@ualberta.ca"
+    "Last Name": "Kazemian"
   },
   {
+    "Email Address": "jhelberg@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jhelberg@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "lemelled@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "lemelled@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "janelle.cuevas@mail.utoronto.ca",
     "First Name": "Janelle",
-    "Last Name": "Cuevas",
-    "Email Address": "janelle.cuevas@mail.utoronto.ca"
+    "Last Name": "Cuevas"
   },
   {
+    "Email Address": "yasui@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "yasui@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "quirozju@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "quirozju@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "z399yang@uwaterloo.ca",
     "First Name": "Jenny",
-    "Last Name": "Yang",
-    "Email Address": "z399yang@uwaterloo.ca"
+    "Last Name": "Yang"
   },
   {
+    "Email Address": "loyaljot@ualberta.ca",
     "First Name": "Loyal",
-    "Last Name": "Bajwa",
-    "Email Address": "loyaljot@ualberta.ca"
+    "Last Name": "Bajwa"
   },
   {
+    "Email Address": "lrathod@ualberta.ca",
     "First Name": "Luv",
-    "Last Name": "Rathod",
-    "Email Address": "lrathod@ualberta.ca"
+    "Last Name": "Rathod"
   },
   {
+    "Email Address": "eknechte@ualberta.ca",
     "First Name": "Eden",
-    "Last Name": "Knechtel",
-    "Email Address": "eknechte@ualberta.ca"
+    "Last Name": "Knechtel"
   },
   {
+    "Email Address": "aeherman@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aeherman@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yashna@ualberta.ca",
     "First Name": "Yashna",
-    "Last Name": "Islam",
-    "Email Address": "yashna@ualberta.ca"
+    "Last Name": "Islam"
   },
   {
+    "Email Address": "Ypatel2@ualberta.ca",
     "First Name": "yash",
-    "Last Name": "patel",
-    "Email Address": "Ypatel2@ualberta.ca"
+    "Last Name": "patel"
   },
   {
+    "Email Address": "psrivastava@wpi.edu",
     "First Name": "Prakhar",
-    "Last Name": "Srivastava",
-    "Email Address": "psrivastava@wpi.edu"
+    "Last Name": "Srivastava"
   },
   {
+    "Email Address": "hb2635@columbia.edu",
     "First Name": "Hima Bindu",
-    "Last Name": "Bhardwaj",
-    "Email Address": "hb2635@columbia.edu"
+    "Last Name": "Bhardwaj"
   },
   {
+    "Email Address": "yeajin3@ualberta.ca",
     "First Name": "Yeajin(Jin)",
-    "Last Name": "Ko",
-    "Email Address": "yeajin3@ualberta.ca"
+    "Last Name": "Ko"
   },
   {
+    "Email Address": "shweta3@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "shweta3@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "marsh2@stolaf.edu",
     "First Name": "Annabelle",
-    "Last Name": "Marsh",
-    "Email Address": "marsh2@stolaf.edu"
+    "Last Name": "Marsh"
   },
   {
+    "Email Address": "enlewis@ualberta.ca",
     "First Name": "Erik",
-    "Last Name": "Lewis",
-    "Email Address": "enlewis@ualberta.ca"
+    "Last Name": "Lewis"
   },
   {
+    "Email Address": "hkang@uqlberta.ca",
     "First Name": "Brian",
-    "Last Name": "Kang",
-    "Email Address": "hkang@uqlberta.ca"
+    "Last Name": "Kang"
   },
   {
+    "Email Address": "jelliot1@ualberta.ca",
     "First Name": "Jason",
-    "Last Name": "Elliot",
-    "Email Address": "jelliot1@ualberta.ca"
+    "Last Name": "Elliot"
   },
   {
+    "Email Address": "kitchenette@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kitchenette@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "events@teamupscience.com",
     "First Name": "Teresa",
-    "Last Name": "Nguyen-Pham",
-    "Email Address": "events@teamupscience.com"
+    "Last Name": "Nguyen-Pham"
   },
   {
+    "Email Address": "aabels@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aabels@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "Manuja.gokulan@sv.cmu.edu",
     "First Name": "Manuja",
-    "Last Name": "Gokulan",
-    "Email Address": "Manuja.gokulan@sv.cmu.edu"
+    "Last Name": "Gokulan"
   },
   {
+    "Email Address": "shanemel@ualberta.ca",
     "First Name": "Shanemel",
-    "Last Name": "Asuncion",
-    "Email Address": "shanemel@ualberta.ca"
+    "Last Name": "Asuncion"
   },
   {
+    "Email Address": "n.gergel1@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "n.gergel1@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "gd1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "gd1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "debangan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "debangan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "shrestarao6@gmail.com",
     "First Name": "Shresta",
-    "Last Name": "Srinivas Rao",
-    "Email Address": "shrestarao6@gmail.com"
+    "Last Name": "Srinivas Rao"
   },
   {
+    "Email Address": "anjalisonawane2513@gmail.com",
     "First Name": "Anjali",
-    "Last Name": "Sonawane",
-    "Email Address": "anjalisonawane2513@gmail.com"
+    "Last Name": "Sonawane"
   },
   {
+    "Email Address": "shoven@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "shoven@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yfan4@ualberta.ca",
     "First Name": "Yige",
-    "Last Name": "Fan",
-    "Email Address": "yfan4@ualberta.ca"
+    "Last Name": "Fan"
   },
   {
+    "Email Address": "sfa@ualberta.ca",
     "First Name": "Samiha",
-    "Last Name": "Ali",
-    "Email Address": "sfa@ualberta.ca"
+    "Last Name": "Ali"
   },
   {
+    "Email Address": "mpatel2@ualberta.ca",
     "First Name": "Mira",
-    "Last Name": "Patel",
-    "Email Address": "mpatel2@ualberta.ca"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "william.james.jw@gmail.com",
     "First Name": "James",
-    "Last Name": "Kivai",
-    "Email Address": "william.james.jw@gmail.com"
+    "Last Name": "Kivai"
   },
   {
+    "Email Address": "sarah.nhan@ubc.ca",
     "First Name": "Sarah",
-    "Last Name": "Nhan",
-    "Email Address": "sarah.nhan@ubc.ca"
+    "Last Name": "Nhan"
   },
   {
+    "Email Address": "angel.lizthomas@gmail.com",
     "First Name": "Angel",
-    "Last Name": "Thomas",
-    "Email Address": "angel.lizthomas@gmail.com"
+    "Last Name": "Thomas"
   },
   {
+    "Email Address": "kulpreet@ualberta.ca",
     "First Name": "Kulpreet",
-    "Last Name": "Cheema",
-    "Email Address": "kulpreet@ualberta.ca"
+    "Last Name": "Cheema"
   },
   {
+    "Email Address": "asiadoma@ualberta.ca",
     "First Name": "Ahmed",
-    "Last Name": "Siadomar",
-    "Email Address": "asiadoma@ualberta.ca"
+    "Last Name": "Siadomar"
   },
   {
+    "Email Address": "Aliceailiang@gmail.com",
     "First Name": "Alice",
-    "Last Name": "Liang",
-    "Email Address": "Aliceailiang@gmail.com"
+    "Last Name": "Liang"
   },
   {
+    "Email Address": "xw8@ualberta.ca",
     "First Name": "Ben",
-    "Last Name": "Wang",
-    "Email Address": "xw8@ualberta.ca"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "seltink@gmail.com",
     "First Name": "Selene",
-    "Last Name": "Basurto V",
-    "Email Address": "seltink@gmail.com"
+    "Last Name": "Basurto V"
   },
   {
+    "Email Address": "marcus5@ualberta.ca",
     "First Name": "Marcus",
-    "Last Name": "Kim",
-    "Email Address": "marcus5@ualberta.ca"
+    "Last Name": "Kim"
   },
   {
+    "Email Address": "rjellis@ualberta.ca",
     "First Name": "Rachel",
-    "Last Name": "Ellis",
-    "Email Address": "rjellis@ualberta.ca"
+    "Last Name": "Ellis"
   },
   {
+    "Email Address": "pm2817@nyu.edu",
     "First Name": "Pooja",
-    "Last Name": "Mehta",
-    "Email Address": "pm2817@nyu.edu"
+    "Last Name": "Mehta"
   },
   {
+    "Email Address": "shubhang@psu.edu",
     "First Name": "Shubhang",
-    "Last Name": "Sharma",
-    "Email Address": "shubhang@psu.edu"
+    "Last Name": "Sharma"
   },
   {
+    "Email Address": "abbas.sobhi@ualberta.ca",
     "First Name": "Sayedabbas",
-    "Last Name": "Sobhi",
-    "Email Address": "abbas.sobhi@ualberta.ca"
+    "Last Name": "Sobhi"
   },
   {
+    "Email Address": "gaiya@ualberta.ca",
     "First Name": "Abuni",
-    "Last Name": "Gaiya",
-    "Email Address": "gaiya@ualberta.ca"
+    "Last Name": "Gaiya"
   },
   {
+    "Email Address": "aseniuk@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aseniuk@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "bchong1@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bchong1@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "roysten.rodrigues@mavs.uta.edu",
     "First Name": "Roysten",
-    "Last Name": "Rodrigues",
-    "Email Address": "roysten.rodrigues@mavs.uta.edu"
+    "Last Name": "Rodrigues"
   },
   {
+    "Email Address": "ranasunj@ualberta.ca",
     "First Name": "Rana",
-    "Last Name": "Thind",
-    "Email Address": "ranasunj@ualberta.ca"
+    "Last Name": "Thind"
   },
   {
+    "Email Address": "nadi@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "nadi@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "mikal@ualberta.ca",
     "First Name": "Mikal",
-    "Last Name": "Kotadia",
-    "Email Address": "mikal@ualberta.ca"
+    "Last Name": "Kotadia"
   },
   {
+    "Email Address": "jyuen@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "jyuen@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "aawong1@ualberta.ca",
     "First Name": "Aidan",
-    "Last Name": "Wong",
-    "Email Address": "aawong1@ualberta.ca"
+    "Last Name": "Wong"
   },
   {
+    "Email Address": "Hliu1@ualberta.ca",
     "First Name": "Hongwei",
-    "Last Name": "Liu",
-    "Email Address": "Hliu1@ualberta.ca"
+    "Last Name": "Liu"
   },
   {
+    "Email Address": "alicia.emberso.bremer@gmail.com",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "alicia.emberso.bremer@gmail.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "sduffett@ualberta.ca",
     "First Name": "Sahara",
-    "Last Name": "Duffett",
-    "Email Address": "sduffett@ualberta.ca"
+    "Last Name": "Duffett"
   },
   {
+    "Email Address": "sdai3@ualberta.ca",
     "First Name": "Shiyu",
-    "Last Name": "Dai",
-    "Email Address": "sdai3@ualberta.ca"
+    "Last Name": "Dai"
   },
   {
+    "Email Address": "cdmacken@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "cdmacken@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "driabajwa@yahoo.com",
     "First Name": "Ehlam",
-    "Last Name": "",
-    "Email Address": "driabajwa@yahoo.com"
+    "Last Name": ""
   },
   {
+    "Email Address": "shokara@uci.edu",
     "First Name": "Akarshan",
-    "Last Name": "Shokar",
-    "Email Address": "shokara@uci.edu"
+    "Last Name": "Shokar"
   },
   {
+    "Email Address": "jmark@ualberta.ca",
     "First Name": "Jacy",
-    "Last Name": "Mark",
-    "Email Address": "jmark@ualberta.ca"
+    "Last Name": "Mark"
   },
   {
+    "Email Address": "sungsu@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sungsu@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ackimenk@ualberta.ca",
     "First Name": "Jordan",
-    "Last Name": "Ackimenko",
-    "Email Address": "ackimenk@ualberta.ca"
+    "Last Name": "Ackimenko"
   },
   {
+    "Email Address": "kdehaan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kdehaan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "rppatel@iastate.edu",
     "First Name": "Richa",
-    "Last Name": "Patel",
-    "Email Address": "rppatel@iastate.edu"
+    "Last Name": "Patel"
   },
   {
+    "Email Address": "azamani1@ualberta.ca",
     "First Name": "Ali",
-    "Last Name": "Zamani",
-    "Email Address": "azamani1@ualberta.ca"
+    "Last Name": "Zamani"
   },
   {
+    "Email Address": "Ramandeep_D06@hotmail.com",
     "First Name": "Raman",
-    "Last Name": "D",
-    "Email Address": "Ramandeep_D06@hotmail.com"
+    "Last Name": "D"
   },
   {
+    "Email Address": "antonella.colon@upr.edu",
     "First Name": "Antonella",
-    "Last Name": "Colon",
-    "Email Address": "antonella.colon@upr.edu"
+    "Last Name": "Colon"
   },
   {
+    "Email Address": "latyshev@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "latyshev@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "wmarshal@ualberta.ca",
     "First Name": "William",
-    "Last Name": "Marshall",
-    "Email Address": "wmarshal@ualberta.ca"
+    "Last Name": "Marshall"
   },
   {
+    "Email Address": "bdlu1@ualberta.ca",
     "First Name": "Brian",
-    "Last Name": "Lu",
-    "Email Address": "bdlu1@ualberta.ca"
+    "Last Name": "Lu"
   },
   {
+    "Email Address": "pxj190008@utdallas.edu",
     "First Name": "Pallavi",
-    "Last Name": "Jethwani",
-    "Email Address": "pxj190008@utdallas.edu"
+    "Last Name": "Jethwani"
   },
   {
+    "Email Address": "Copeland@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "Copeland@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "bdha@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "bdha@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "Swang3@andrew.cmu.edu",
     "First Name": "Stephanie",
-    "Last Name": "Wang",
-    "Email Address": "Swang3@andrew.cmu.edu"
+    "Last Name": "Wang"
   },
   {
+    "Email Address": "hz6@ualberta.ca",
     "First Name": "Haonan",
-    "Last Name": "Zhang",
-    "Email Address": "hz6@ualberta.ca"
+    "Last Name": "Zhang"
   },
   {
+    "Email Address": "heeba@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "heeba@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "anushka1@ualberta.ca",
     "First Name": "Anushka",
-    "Last Name": "Khare",
-    "Email Address": "anushka1@ualberta.ca"
+    "Last Name": "Khare"
   },
   {
+    "Email Address": "svemula@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "svemula@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "jusong@ualberta.ca",
     "First Name": "Jusong",
-    "Last Name": "Baek",
-    "Email Address": "jusong@ualberta.ca"
+    "Last Name": "Baek"
   },
   {
+    "Email Address": "kalvin.eng@ualberta.ca",
     "First Name": "K",
-    "Last Name": "E",
-    "Email Address": "kalvin.eng@ualberta.ca"
+    "Last Name": "E"
   },
   {
+    "Email Address": "minhnha@ualberta.ca",
     "First Name": "Mina",
-    "Last Name": "Nguyen",
-    "Email Address": "minhnha@ualberta.ca"
+    "Last Name": "Nguyen"
   },
   {
+    "Email Address": "wboytinc@ualberta.ca",
     "First Name": "Will",
-    "Last Name": "Boytinck",
-    "Email Address": "wboytinc@ualberta.ca"
+    "Last Name": "Boytinck"
   },
   {
+    "Email Address": "stao2@ualberta.ca",
     "First Name": "Tally",
-    "Last Name": "Tao",
-    "Email Address": "stao2@ualberta.ca"
+    "Last Name": "Tao"
   },
   {
+    "Email Address": "aqandhar@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "aqandhar@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ktwong@ualberta.ca",
     "First Name": "Kyla",
-    "Last Name": "Wong",
-    "Email Address": "ktwong@ualberta.ca"
+    "Last Name": "Wong"
   },
   {
+    "Email Address": "swcoutin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "swcoutin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "ehill@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "ehill@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "e19cse005@bennett.edu.in",
     "First Name": "Mayesh",
-    "Last Name": "Mohapatra",
-    "Email Address": "e19cse005@bennett.edu.in"
+    "Last Name": "Mohapatra"
   },
   {
+    "Email Address": "gtahilia@syr.edu",
     "First Name": "Geeta",
-    "Last Name": "T",
-    "Email Address": "gtahilia@syr.edu"
+    "Last Name": "T"
   },
   {
+    "Email Address": "chivasa@ualberta.ca",
     "First Name": "Tatenda",
-    "Last Name": "Chivasa",
-    "Email Address": "chivasa@ualberta.ca"
+    "Last Name": "Chivasa"
   },
   {
+    "Email Address": "connie.duniece@ualberta.ca",
     "First Name": "Connie",
-    "Last Name": "Duniece",
-    "Email Address": "connie.duniece@ualberta.ca"
+    "Last Name": "Duniece"
   },
   {
+    "Email Address": "dsmohame@ualberta.ca",
+    "First Name": "Dania",
+    "Last Name": "Mohamed"
+  },
+  {
+    "Email Address": "tirumand@ualberta.ca",
     "First Name": "Lasya",
-    "Last Name": "Tirumandas",
-    "Email Address": "tirumand@ualberta.ca"
+    "Last Name": "Tirumandas"
   },
   {
+    "Email Address": "topalan@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "topalan@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "xinglin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "xinglin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "yan.luoyan@gmail.com",
     "First Name": "Yan",
-    "Last Name": "Luo",
-    "Email Address": "yan.luoyan@gmail.com"
+    "Last Name": "Luo"
   },
   {
+    "Email Address": "kboyle@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "kboyle@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "benyamin@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "benyamin@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "seaton1@ualberta.ca",
     "First Name": "Shane",
-    "Last Name": "Eaton",
-    "Email Address": "seaton1@ualberta.ca"
+    "Last Name": "Eaton"
   },
   {
+    "Email Address": "schopra1@ualberta.ca",
     "First Name": "SHIV",
-    "Last Name": "CHOPRA",
-    "Email Address": "schopra1@ualberta.ca"
+    "Last Name": "CHOPRA"
   },
   {
+    "Email Address": "gul@ualberta.ca",
     "First Name": "Saba",
-    "Last Name": "Gul",
-    "Email Address": "gul@ualberta.ca"
+    "Last Name": "Gul"
   },
   {
+    "Email Address": "knewbury@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "knewbury@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "heebaparvez@gmail.com",
     "First Name": "Heeba",
-    "Last Name": "Parvez",
-    "Email Address": "heebaparvez@gmail.com"
+    "Last Name": "Parvez"
   },
   {
+    "Email Address": "seungwan@ualberta.ca",
     "First Name": "Alvin",
-    "Last Name": "Shon",
-    "Email Address": "seungwan@ualberta.ca"
+    "Last Name": "Shon"
   },
   {
+    "Email Address": "csingal@andrew.cmu.edu",
     "First Name": "Chhavi",
-    "Last Name": "Singal",
-    "Email Address": "csingal@andrew.cmu.edu"
+    "Last Name": "Singal"
   },
   {
+    "Email Address": "mrthomas@ualberta.ca",
     "First Name": "Mark",
-    "Last Name": "Thomas",
-    "Email Address": "mrthomas@ualberta.ca"
+    "Last Name": "Thomas"
   },
   {
+    "Email Address": "rkamath@ualberta.ca",
     "First Name": "Rohan",
-    "Last Name": "Kamath",
-    "Email Address": "rkamath@ualberta.ca"
+    "Last Name": "Kamath"
   },
   {
+    "Email Address": "mdam1@ualberta.ca",
     "First Name": "Michael",
-    "Last Name": "Dam",
-    "Email Address": "mdam1@ualberta.ca"
+    "Last Name": "Dam"
   },
   {
+    "Email Address": "akurup@usc.edu",
     "First Name": "Arundhati",
-    "Last Name": "Kurup",
-    "Email Address": "akurup@usc.edu"
+    "Last Name": "Kurup"
   },
   {
+    "Email Address": "idicipul@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "idicipul@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "daveloui@ualberta.ca",
     "First Name": "Fatima",
-    "Last Name": "Davelouis",
-    "Email Address": "daveloui@ualberta.ca"
+    "Last Name": "Davelouis"
   },
   {
+    "Email Address": "machiwal@ualberta.ca",
     "First Name": "Farha",
-    "Last Name": "Machiwala",
-    "Email Address": "machiwal@ualberta.ca"
+    "Last Name": "Machiwala"
   },
   {
+    "Email Address": "sfeng3@ualberta.ca",
     "First Name": "",
-    "Last Name": "",
-    "Email Address": "sfeng3@ualberta.ca"
+    "Last Name": ""
   },
   {
+    "Email Address": "E20CSE347@bennett.edu.in",
     "First Name": "Aayush",
-    "Last Name": "Malhotra",
-    "Email Address": "E20CSE347@bennett.edu.in"
+    "Last Name": "Malhotra"
   },
   {
+    "Email Address": "jarquin@ualberta.ca",
     "First Name": "Carlos",
-    "Last Name": "Jarquin",
-    "Email Address": "jarquin@ualberta.ca"
+    "Last Name": "Jarquin"
   },
   {
+    "Email Address": "rongma@bc.edu",
     "First Name": "Maggie",
-    "Last Name": "Rong",
-    "Email Address": "rongma@bc.edu"
+    "Last Name": "Rong"
   }
 ]


### PR DESCRIPTION
**Changes**
- As per the constitution, article 3.2a:
> The Election Committee must consist of the President, Vice President Admin and one Neutral Party, who will be appointed by the Executive Committee. The Neutral Party will be an executive member who is not running for any positions. If all Executive Members are running, then a general member will be appointed by the Executive Committee as the Neutral Party. The President and Vice President Admin may vote, but the Neutral Party may not vote except in the case of a tie (​see 3.3.n​)
- In this year's election, Chelsea Hong is the neutral party. Therefore, she is ineligible to vote and has been removed from the `mailingList.json` file.

**UI**
> There are no visible UI changes
